### PR TITLE
Add Secret information

### DIFF
--- a/api/v1alpha1/classifierreport_types.go
+++ b/api/v1alpha1/classifierreport_types.go
@@ -26,6 +26,12 @@ const (
 	ClassifierLabelName = "projectsveltos.io/classifier-name"
 
 	ClassifierReportKind = "ClassifierReport"
+
+	// This is the namespace/name of the secret containing the kubeconfig
+	// to send ClassifierReport to management cluster when classifier agent
+	// is configured to send ClassifierReports
+	SecretName      = "classifier-agent"
+	SecretNamespace = "projectsveltos"
 )
 
 // ClassifierReportSpec defines the desired state of ClassifierReport


### PR DESCRIPTION
When Classifier agent is configured to send ClassifierReports back to management cluster, that Secret contains kubeconfig to do so.