### PR TITLE
Add Paused as Cluster field

### DIFF
--- a/api/v1alpha1/cluster_type.go
+++ b/api/v1alpha1/cluster_type.go
@@ -26,6 +26,9 @@ const (
 
 // ClusterSpec defines the desired state of Cluster
 type ClusterSpec struct {
+	// Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
 }
 
 // ClusterStatus defines the status of Cluster

--- a/config/crd/bases/lib.projectsveltos.io_clusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_clusters.yaml
@@ -34,6 +34,11 @@ spec:
             type: object
           spec:
             description: ClusterSpec defines the desired state of Cluster
+            properties:
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
             type: object
           status:
             description: ClusterStatus defines the status of Cluster

--- a/lib/crd/clusters.go
+++ b/lib/crd/clusters.go
@@ -53,6 +53,11 @@ spec:
             type: object
           spec:
             description: ClusterSpec defines the desired state of Cluster
+            properties:
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
             type: object
           status:
             description: ClusterStatus defines the status of Cluster


### PR DESCRIPTION
As for ClusterAPI clusters, an imported cluster can be marked as paused. No addons will be deployed while cluster is set to paused.