### PR TITLE
deployer package: require clusterType

### DIFF
--- a/lib/deployer/client.go
+++ b/lib/deployer/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
@@ -94,13 +95,14 @@ type Options struct {
 func (d *deployer) Deploy(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 	f RequestHandler,
 	m MetricHandler,
 	o Options,
 ) error {
 
-	key := GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -142,10 +144,11 @@ func (d *deployer) Deploy(
 func (d *deployer) GetResult(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 ) Result {
 
-	responseParam, err := getRequestStatus(d, clusterNamespace, clusterName, applicant, featureID, cleanup)
+	responseParam, err := getRequestStatus(d, clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	if err != nil {
 		return Result{
 			ResultStatus: Unavailable,
@@ -180,10 +183,11 @@ func (d *deployer) GetResult(
 
 func (d *deployer) IsInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 ) bool {
 
-	key := GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -200,9 +204,10 @@ func (d *deployer) IsInProgress(
 
 func (d *deployer) CleanupEntries(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool) {
 
-	key := GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 
 	// Remove any entry we might have for this cluster/feature
 

--- a/lib/deployer/fake/client.go
+++ b/lib/deployer/fake/client.go
@@ -19,10 +19,10 @@ package fake
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/go-logr/logr"
-
+	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 )
 
@@ -63,13 +63,14 @@ func (d *fakeDeployer) RegisterFeatureID(
 func (d *fakeDeployer) Deploy(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 	f deployer.RequestHandler,
 	m deployer.MetricHandler,
 	o deployer.Options,
 ) error {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	d.inProgress = append(d.inProgress, key)
 	return nil
 }
@@ -82,10 +83,11 @@ func (d *fakeDeployer) Deploy(
 func (d *fakeDeployer) GetResult(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 ) deployer.Result {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	v, ok := d.results[key]
 	result := deployer.Result{}
 	if !ok {
@@ -104,10 +106,11 @@ func (d *fakeDeployer) GetResult(
 
 func (d *fakeDeployer) IsInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 ) bool {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	for i := range d.inProgress {
 		if d.inProgress[i] == key {
 			return true
@@ -118,9 +121,10 @@ func (d *fakeDeployer) IsInProgress(
 
 func (d *fakeDeployer) CleanupEntries(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool) {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 
 	// Remove any entry we might have for this cluster/feature
 	delete(d.results, key)
@@ -129,21 +133,23 @@ func (d *fakeDeployer) CleanupEntries(
 // StoreResult store request result
 func (d *fakeDeployer) StoreResult(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 	err error,
 ) {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	d.results[key] = err
 }
 
 // StoreInProgress marks request as in progress
 func (d *fakeDeployer) StoreInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType sveltosv1.ClusterType,
 	cleanup bool,
 ) {
 
-	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, cleanup)
+	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
 	d.inProgress = append(d.inProgress, key)
 }
 

--- a/lib/deployer/request_interface.go
+++ b/lib/deployer/request_interface.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 )
 
 const (
@@ -61,11 +63,11 @@ type Result struct {
 
 type RequestHandler func(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, featureID string,
-	o Options, logger logr.Logger) error
+	clusterType sveltosv1.ClusterType, o Options, logger logr.Logger) error
 
 type MetricHandler func(elapsed time.Duration,
 	clusterNamespace, clusterName, featureID string,
-	logger logr.Logger)
+	clusterType sveltosv1.ClusterType, logger logr.Logger)
 
 type DeployerInterface interface {
 	// RegisterFeatureID allows registering a feature ID.
@@ -87,6 +89,7 @@ type DeployerInterface interface {
 	Deploy(
 		ctx context.Context,
 		clusterNamespace, clusterName, applicant, featureID string,
+		clusterType sveltosv1.ClusterType,
 		cleanup bool,
 		f RequestHandler,
 		m MetricHandler,
@@ -99,6 +102,7 @@ type DeployerInterface interface {
 	// removed is currently in progress.
 	IsInProgress(
 		clusterNamespace, clusterName, applicant, featureID string,
+		clusterType sveltosv1.ClusterType,
 		cleanup bool,
 	) bool
 
@@ -106,11 +110,12 @@ type DeployerInterface interface {
 	GetResult(
 		ctx context.Context,
 		clusterNamespace, clusterName, applicant, featureID string,
+		clusterType sveltosv1.ClusterType,
 		cleanup bool,
 	) Result
 
 	// CleanupEntries removes any entry (from any internal data structure) for
 	// given feature
 	CleanupEntries(clusterNamespace, clusterName, applicant, featureID string,
-		cleanup bool)
+		clusterType sveltosv1.ClusterType, cleanup bool)
 }

--- a/lib/deployer/worker_test.go
+++ b/lib/deployer/worker_test.go
@@ -28,14 +28,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 )
 
 var messages chan string
 
 func writeToChannelHandler(ctx context.Context, c client.Client,
-	namespace, name, applicant, featureID string, o deployer.Options,
-	logger logr.Logger) error {
+	namespace, name, applicant, featureID string, clusterType sveltosv1.ClusterType,
+	o deployer.Options, logger logr.Logger) error {
 
 	By("writeToChannelHandler: writing to channel")
 	messages <- "done deploying"
@@ -44,14 +45,15 @@ func writeToChannelHandler(ctx context.Context, c client.Client,
 
 func metricHandler(elapsed time.Duration,
 	clusterNamespace, clusterName, featureID string,
+	clusterType sveltosv1.ClusterType,
 	logger logr.Logger) {
 
 	By("metricHandler: storing metrics")
 }
 
 func doNothingHandler(ctx context.Context, c client.Client,
-	namespace, name, applicant, featureID string, o deployer.Options,
-	logger logr.Logger) error {
+	namespace, name, applicant, featureID string, clusterType sveltosv1.ClusterType,
+	o deployer.Options, logger logr.Logger) error {
 
 	return nil
 }
@@ -63,7 +65,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 
 		outNs, outName, err := deployer.GetClusterFromKey(key)
 		Expect(err).To(BeNil())
@@ -84,7 +86,7 @@ var _ = Describe("Worker", func() {
 		applicant := ""
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, false)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, false)
 
 		outNs, outName, err := deployer.GetClusterFromKey(key)
 		Expect(err).To(BeNil())
@@ -123,7 +125,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -141,7 +143,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -164,13 +166,13 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
 
 		r := map[string]error{key: nil}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
@@ -186,13 +188,13 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 
 		r := map[string]error{key: fmt.Errorf("failed to deploy")}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseFailed(resp)).To(BeTrue())
@@ -208,12 +210,12 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
 
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -228,12 +230,12 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 
 		d.SetJobQueue(key, nil, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -249,7 +251,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		d.SetJobQueue(key, writeToChannelHandler, metricHandler)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 		messages = make(chan string)
@@ -269,7 +271,7 @@ var _ = Describe("Worker", func() {
 			return gotResult
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
 	})


### PR DESCRIPTION
Cluster and SveltosCluster can potentially conflict (be in the same namespace with same name). In order to avoid clash between jobs, always require clusterType.