### PR TITLE
Move ValidateObjectForUpdate to libsveltos

### DIFF
--- a/lib/deployer/deployer_suite_test.go
+++ b/lib/deployer/deployer_suite_test.go
@@ -18,42 +18,140 @@ package deployer_test
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2/klogr"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/internal/test/helpers"
 )
-
-const namespacePrefix = "worker"
 
 var (
-	cancel context.CancelFunc
+	testEnv *helpers.TestEnvironment
+	cancel  context.CancelFunc
+	ctx     context.Context
+	scheme  *runtime.Scheme
 )
 
-func TestDeployer(t *testing.T) {
+var (
+	cacheSyncBackoff = wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    8,
+		Jitter:   0.4,
+	}
+)
+
+const (
+	namespacePrefix = "worker"
+)
+
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Deployer Suite")
+	RunSpecs(t, "Controllers Suite")
 }
 
 var _ = BeforeSuite(func() {
-	By("Creating deployer client")
-	c := fake.NewClientBuilder().WithObjects(nil...).Build()
-	var ctx context.Context
+	By("bootstrapping test environment")
+
 	ctx, cancel = context.WithCancel(context.TODO())
-	deployer.GetClient(ctx, klogr.New(), c, 10)
+
+	var err error
+	scheme, err = setupScheme()
+	Expect(err).To(BeNil())
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join("config", "crd", "bases"),
+	}, scheme)
+	testEnv, err = testEnvConfig.Build(scheme)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		By("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+
+	if synced := testEnv.GetCache().WaitForCacheSync(ctx); !synced {
+		time.Sleep(time.Second)
+	}
 })
 
 var _ = AfterSuite(func() {
 	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
 })
 
 func randomString() string {
 	const length = 10
 	return util.RandomString(length)
+}
+
+func setupScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// waitForObject waits for the cache to be updated helps in preventing test flakes due to the cache sync delays.
+func waitForObject(ctx context.Context, c client.Client, obj client.Object) error {
+	// Makes sure the cache is updated with the new object
+	objCopy := obj.DeepCopyObject().(client.Object)
+	key := client.ObjectKeyFromObject(obj)
+	if err := wait.ExponentialBackoff(
+		cacheSyncBackoff,
+		func() (done bool, err error) {
+			if err := c.Get(ctx, key, objCopy); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}); err != nil {
+		return errors.Wrapf(err, "object %s, %s is not being added to the testenv client cache", obj.GetObjectKind().GroupVersionKind().String(), key)
+	}
+	return nil
+}
+
+func addTypeInformationToObject(scheme *runtime.Scheme, obj client.Object) error {
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
+	}
+
+	for _, gvk := range gvks {
+		if gvk.Kind == "" {
+			continue
+		}
+		if gvk.Version == "" || gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
+	}
+
+	return nil
 }

--- a/lib/deployer/utils.go
+++ b/lib/deployer/utils.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	// ReferenceLabelKind is added to each policy deployed by a ClusterSummary
+	// instance to a CAPI Cluster. Indicates the Kind (ConfigMap or Secret)
+	// containing the policy.
+	ReferenceLabelKind = "projectsveltos.io/reference-kind"
+
+	// ReferenceLabelName is added to each policy deployed by a ClusterSummary
+	// instance to a CAPI Cluster. Indicates the name of the ConfigMap/Secret
+	// containing the policy.
+	ReferenceLabelName = "projectsveltos.io/reference-name"
+
+	// ReferenceLabelNamespace is added to each policy deployed by a ClusterSummary
+	// instance to a CAPI Cluster. Indicates the namespace of the ConfigMap/Secret
+	// containing the policy.
+	ReferenceLabelNamespace = "projectsveltos.io/reference-namespace"
+
+	// PolicyHash is the annotation set on a policy when deployed in a CAPI
+	// cluster.
+	PolicyHash = "projectsveltos.io/hash"
+)
+
+type conflictError struct {
+	message string
+}
+
+func (e *conflictError) Error() string {
+	return e.message
+}
+
+// validateObjectForUpdate finds if object currently exists. If object exists:
+// - verifies this object was created by same ConfigMap/Secret. Returns an error otherwise.
+// This is needed to prevent misconfigurations. An example would be when different
+// ConfigMaps are referenced by ClusterProfile(s) or RoleRequest(s) and contain same policy
+// namespace/name (content might be different) and are about to be deployed in the same cluster;
+// Return an error if validation fails. Return also whether the object currently exists or not.
+// If object exists, return value of PolicyHash annotation.
+func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
+	object *unstructured.Unstructured,
+	referenceKind, referenceNamespace, referenceName string) (exist bool, hash string, err error) {
+
+	if object == nil {
+		return false, "", nil
+	}
+
+	currentObject, err := dr.Get(ctx, object.GetName(), metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+
+	if labels := currentObject.GetLabels(); labels != nil {
+		kind, kindOk := labels[ReferenceLabelKind]
+		namespace, namespaceOk := labels[ReferenceLabelNamespace]
+		name, nameOk := labels[ReferenceLabelName]
+
+		if kindOk {
+			if kind != referenceKind {
+				return true, "", &conflictError{
+					message: fmt.Sprintf("conflict: policy (kind: %s) %s is currently deployed by %s: %s/%s",
+						object.GetKind(), object.GetName(), kind, namespace, name)}
+			}
+		}
+		if namespaceOk {
+			if namespace != referenceNamespace {
+				return true, "", &conflictError{
+					message: fmt.Sprintf("conflict: policy (kind: %s) %s is currently deployed by %s: %s/%s",
+						object.GetKind(), object.GetName(), kind, namespace, name)}
+			}
+		}
+		if nameOk {
+			if name != referenceName {
+				return true, "", &conflictError{
+					message: fmt.Sprintf("conflict: policy (kind: %s) %s is currently deployed by %s: %s/%s",
+						object.GetKind(), object.GetName(), kind, namespace, name)}
+			}
+		}
+	}
+
+	// Only in case object exists and there are no conflicts, return hash
+	if annotations := currentObject.GetAnnotations(); annotations != nil {
+		hash = annotations[PolicyHash]
+	}
+
+	return true, hash, nil
+}

--- a/lib/deployer/utils_test.go
+++ b/lib/deployer/utils_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/lib/utils"
+)
+
+const (
+	nsTemplate = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s`
+)
+
+var _ = Describe("Client", func() {
+	It("ValidateObjectForUpdate returns error when resource is already installed because of different ConfigMap",
+		func() {
+			name := randomString()
+
+			nsInstance := fmt.Sprintf(nsTemplate, name)
+
+			configMapNs := randomString()
+			configMapName := randomString()
+			policyHash := randomString()
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{
+						deployer.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+						deployer.ReferenceLabelName:      configMapName,
+						deployer.ReferenceLabelNamespace: configMapNs,
+					},
+					Annotations: map[string]string{
+						deployer.PolicyHash: policyHash,
+					},
+				},
+			}
+
+			Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+			Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+			Expect(addTypeInformationToObject(scheme, ns))
+
+			dr, err := utils.GetDynamicResourceInterface(testEnv.Config, ns.GroupVersionKind(), "")
+			Expect(err).To(BeNil())
+
+			var u *unstructured.Unstructured
+			u, err = utils.GetUnstructured([]byte(nsInstance))
+			Expect(err).To(BeNil())
+
+			// If different configMap, return error
+			_, _, err = deployer.ValidateObjectForUpdate(context.TODO(), dr, u, string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+				randomString(), randomString())
+			Expect(err).ToNot(BeNil())
+
+			// If same configMap, return no error
+			var exist bool
+			var hash string
+			exist, hash, err = deployer.ValidateObjectForUpdate(context.TODO(), dr, u, string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+				configMapNs, configMapName)
+			Expect(err).To(BeNil())
+			Expect(exist).To(BeTrue())
+			Expect(hash).To(Equal(policyHash))
+		})
+})


### PR DESCRIPTION
ClusterProfile and RoleRequest both references ConfigMaps/Secrets containing policies that need to be deployed in matching clusters.

All resources contained in a referenced ConfigMap/Secret are deployed in a matching managed cluster.

Because same resource contained in a ConfigMap/Secret, can also be contained in other referenced ConfigMaps/Secrets, before deploying a resource in a matching cluster following validation is needed: 1) validate resource is not already present;
2) if resource is already present, validate that it was contained by the same referenced ConfigMap/Secret trying to deploy it now.

This code was originally in sveltos-manager. Given RoleRequest needs same validation, moving it (along with Labels/Annotation) in libsveltos.