### PR TITLE
Rename RoleRequestLabel

### DIFF
--- a/api/v1alpha1/rolerequest_type.go
+++ b/api/v1alpha1/rolerequest_type.go
@@ -26,9 +26,9 @@ const (
 
 	RoleRequestKind = "RoleRequest"
 
-	// RoleRequestLabelName is added to each object generated for a RoleRequest
+	// RoleRequestLabel is added to each object generated for a RoleRequest
 	// in both management and managed clusters
-	RoleRequestLabelName = "projectsveltos.io/role-request-name"
+	RoleRequestLabel = "projectsveltos.io/role-request-name"
 
 	FeatureRoleRequest = "RoleRequest"
 )


### PR DESCRIPTION
Multiple RoleRequests can be generated for same serviceaccount.

Only one secret is created in the management cluster for each serviceAccount/cluster.
Rename label to indicate resources created by RoleRequests. RoleRequests will be ownerReferences of such resources.