### PR TITLE
Add utilities for role secrets

### DIFF
--- a/lib/roles/export_test.go
+++ b/lib/roles/export_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+const (
+	ClusterNameLabel        = clusterNameLabel
+	ServiceAccountNameLabel = serviceAccountNameLabel
+	Key                     = key
+)

--- a/lib/roles/roles.go
+++ b/lib/roles/roles.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+)
+
+const (
+	clusterNameLabel = "projectsveltos.io/role-cluster"
+
+	serviceAccountNameLabel = "projectsveltos.io/role-service-account"
+
+	key = "kubeconfig"
+)
+
+// Platform admin can create RoleRequests to grant other admins
+// permission in managed cluster.
+// When RoleRequest is created, Sveltos deploys ClusterRoles/Roles
+// with corresponding ClusterRoleBindings/RoleBindings and ServiceAccounts
+// in managed clusters.
+// Finally, Kubeconfig for each Cluster/ServiceAccount is taken and stored
+// in the management cluster in a Secret.
+//
+// Here there are utilities to work with those secrets.
+
+// GetSecret returns the secret to be used to store kubeconfig for serviceAccountName
+// in cluster. It returns nil if it does not exist yet.
+func GetSecret(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName, serviceAccountName string, clusterType sveltosv1.ClusterType) (*corev1.Secret, error) {
+
+	secretList := &corev1.SecretList{}
+	err := c.List(ctx, secretList, getListOptionsForSecret(clusterNamespace, clusterName, serviceAccountName)...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(secretList.Items) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &secretList.Items[0], nil
+	default:
+		return nil, fmt.Errorf("found more than one existing secret for %s in cluster %s/%s",
+			serviceAccountName, clusterNamespace, clusterName)
+	}
+}
+
+// CreateSecret returns the secret to be used to store kubeconfig for serviceAccountName
+// in cluster. It does create it if it does not exist yet.
+// If Secret already exists, updates Data section if necessary (kubeconfig is different)
+func CreateSecret(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName, serviceAccountName string, clusterType sveltosv1.ClusterType,
+	kubeconfig []byte) (*corev1.Secret, error) {
+
+	secretList := &corev1.SecretList{}
+	err := c.List(ctx, secretList, getListOptionsForSecret(clusterNamespace, clusterName, serviceAccountName)...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(secretList.Items) {
+	case 0:
+		return createSecret(ctx, c, clusterNamespace, clusterName, serviceAccountName, kubeconfig)
+	case 1:
+		if shouldUpdate(&secretList.Items[0], kubeconfig) {
+			return updateSecretData(ctx, c, &secretList.Items[0], kubeconfig)
+		}
+		return &secretList.Items[0], nil
+	default:
+		return nil, fmt.Errorf("found more than one existing secret for %s in cluster %s/%s",
+			serviceAccountName, clusterNamespace, clusterName)
+	}
+}
+
+// DeleteSecret deletes secret used to store kubeconfig for serviceAccountName in cluster
+func DeleteSecret(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName, serviceAccountName string, clusterType sveltosv1.ClusterType) error {
+
+	secretList := &corev1.SecretList{}
+	err := c.List(ctx, secretList, getListOptionsForSecret(clusterNamespace, clusterName, serviceAccountName)...)
+	if err != nil {
+		return nil
+	}
+
+	for i := range secretList.Items {
+		err = c.Delete(ctx, &secretList.Items[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getSha256(text string) string {
+	h := sha256.New()
+	h.Write([]byte(text))
+	hash := h.Sum(nil)
+	return fmt.Sprintf("%x", hash)
+}
+
+func createSecret(ctx context.Context, c client.Client,
+	namespace, clusterName, serviceAccountName string, kubeconfig []byte) (*corev1.Secret, error) {
+
+	var config string
+	config += clusterName
+	config += serviceAccountName
+	name := fmt.Sprintf("sveltos-%s", getSha256(config))
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				clusterNameLabel:        clusterName,
+				serviceAccountNameLabel: serviceAccountName,
+			},
+		},
+		Data: map[string][]byte{
+			key: kubeconfig,
+		},
+	}
+
+	if err := c.Create(ctx, secret); err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+func getListOptionsForSecret(clusterNamespace, clusterName, serviceAccountName string) []client.ListOption {
+	return []client.ListOption{
+		client.InNamespace(clusterNamespace),
+		client.MatchingLabels{
+			clusterNameLabel:        clusterName,
+			serviceAccountNameLabel: serviceAccountName,
+		},
+	}
+}
+
+// shouldUpdate returns true if secret needs to be updated, which happens
+// when kubeconfig stored in the secret and the new kubeconfig are different.
+func shouldUpdate(secret *corev1.Secret, kubeconfig []byte) bool {
+	if secret.Data == nil {
+		return true
+	}
+
+	return !reflect.DeepEqual(secret.Data[key], kubeconfig)
+}
+
+// updateSecretData updates secret data section
+func updateSecretData(ctx context.Context, c client.Client,
+	secret *corev1.Secret, kubeconfig []byte) (*corev1.Secret, error) {
+
+	secret.Data = map[string][]byte{
+		key: kubeconfig,
+	}
+
+	err := c.Update(ctx, secret)
+	return secret, err
+}

--- a/lib/roles/roles_suite_test.go
+++ b/lib/roles/roles_suite_test.go
@@ -1,0 +1,42 @@
+package roles_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+var (
+	scheme *runtime.Scheme
+)
+
+func TestRoles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Roles Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+
+	var err error
+	scheme, err = setupScheme()
+	Expect(err).To(BeNil())
+})
+
+func randomString() string {
+	const length = 10
+	return util.RandomString(length)
+}
+
+func setupScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/lib/roles/roles_test.go
+++ b/lib/roles/roles_test.go
@@ -1,0 +1,200 @@
+package roles_test
+
+import (
+	"context"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/roles"
+)
+
+var _ = Describe("Roles", func() {
+	It("GetSecret returns  nil when secret does not exist", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		secret, err := roles.GetSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(secret).To(BeNil())
+	})
+
+	It("GetSecret returns existing secret", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+		kubeconfig := []byte(randomString())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      randomString(),
+				Labels: map[string]string{
+					roles.ClusterNameLabel:        clusterName,
+					roles.ServiceAccountNameLabel: serviceaccountName,
+				},
+			},
+			Data: map[string][]byte{
+				roles.Key: kubeconfig,
+			},
+		}
+
+		initObjects := []client.Object{secret}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		currentSecret, err := roles.GetSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(currentSecret).ToNot(BeNil())
+		Expect(currentSecret.Namespace).To(Equal(clusterNamespace))
+		Expect(currentSecret.Name).To(Equal(secret.Name))
+
+		Expect(currentSecret.Labels).ToNot(BeNil())
+		v, ok := currentSecret.Labels[roles.ServiceAccountNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(serviceaccountName))
+
+		v, ok = currentSecret.Labels[roles.ClusterNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(clusterName))
+
+		Expect(currentSecret.Data).ToNot(BeNil())
+		var currentKubeconfig []byte
+		currentKubeconfig, ok = currentSecret.Data[roles.Key]
+		Expect(ok).To(BeTrue())
+		Expect(reflect.DeepEqual(currentKubeconfig, kubeconfig)).To(BeTrue())
+	})
+
+	It("CreateSecret creates secret and returns it", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		secret, err := roles.CreateSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos,
+			[]byte(randomString()))
+		Expect(err).To(BeNil())
+		Expect(secret).ToNot(BeNil())
+		Expect(secret.Namespace).To(Equal(clusterNamespace))
+
+		Expect(secret.Labels).ToNot(BeNil())
+		v, ok := secret.Labels[roles.ServiceAccountNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(serviceaccountName))
+
+		v, ok = secret.Labels[roles.ClusterNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(clusterName))
+	})
+
+	It("CreateSecret returns existing secret updating data section", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+		kubeconfig := []byte(randomString())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      randomString(),
+				Labels: map[string]string{
+					roles.ClusterNameLabel:        clusterName,
+					roles.ServiceAccountNameLabel: serviceaccountName,
+				},
+			},
+			Data: map[string][]byte{
+				roles.Key: []byte(randomString()),
+			},
+		}
+
+		initObjects := []client.Object{secret}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		currentSecret, err := roles.CreateSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos,
+			kubeconfig)
+		Expect(err).To(BeNil())
+		Expect(currentSecret).ToNot(BeNil())
+		Expect(currentSecret.Namespace).To(Equal(clusterNamespace))
+		Expect(currentSecret.Name).To(Equal(secret.Name))
+
+		Expect(currentSecret.Labels).ToNot(BeNil())
+		v, ok := currentSecret.Labels[roles.ServiceAccountNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(serviceaccountName))
+
+		v, ok = currentSecret.Labels[roles.ClusterNameLabel]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(clusterName))
+
+		Expect(currentSecret.Data).ToNot(BeNil())
+		var currentKubeconfig []byte
+		currentKubeconfig, ok = currentSecret.Data[roles.Key]
+		Expect(ok).To(BeTrue())
+		Expect(reflect.DeepEqual(currentKubeconfig, kubeconfig)).To(BeTrue())
+	})
+
+	It("DeleteSecret succeeds when secret does not exist", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := roles.DeleteSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+	})
+
+	It("DeleteSecret deletes existing secret", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      randomString(),
+				Labels: map[string]string{
+					roles.ClusterNameLabel:        clusterName,
+					roles.ServiceAccountNameLabel: serviceaccountName,
+				},
+			},
+		}
+
+		initObjects := []client.Object{secret}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		err := roles.DeleteSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+
+		listOptions := []client.ListOption{
+			client.InNamespace(clusterNamespace),
+			client.MatchingLabels{
+				roles.ClusterNameLabel:        clusterName,
+				roles.ServiceAccountNameLabel: serviceaccountName,
+			},
+		}
+
+		secretList := &corev1.SecretList{}
+		Expect(c.List(context.TODO(), secretList, listOptions...)).To(Succeed())
+		Expect(len(secretList.Items)).To(BeZero())
+	})
+})


### PR DESCRIPTION
Platform admin can create RoleRequest to grant tenant admins permissions in managed clusters.
When a RoleRequest is created, Sveltos creates:
1. ClusterRoles/Roles
2. ClusterRoleBindings/RoleBindings
3. ServiceAccount

in managed clusters.

Then for each pair tenant admin/cluster, a Secret is created containing the kubeconfig to access the managed cluster on behalf of the tenant admin.

This PR contains utilities needed for different sveltos services to manage those secrets.