### PR TITLE
Add onwerReferences to secret created for roles

### DIFF
--- a/lib/deployer/client.go
+++ b/lib/deployer/client.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
@@ -95,7 +95,7 @@ type Options struct {
 func (d *deployer) Deploy(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 	f RequestHandler,
 	m MetricHandler,
@@ -144,7 +144,7 @@ func (d *deployer) Deploy(
 func (d *deployer) GetResult(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 ) Result {
 
@@ -183,7 +183,7 @@ func (d *deployer) GetResult(
 
 func (d *deployer) IsInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 ) bool {
 
@@ -204,7 +204,7 @@ func (d *deployer) IsInProgress(
 
 func (d *deployer) CleanupEntries(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool) {
 
 	key := GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)

--- a/lib/deployer/client_test.go
+++ b/lib/deployer/client_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 )
 
@@ -52,7 +52,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -64,7 +64,7 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Deployed))
 	})
@@ -75,7 +75,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -87,7 +87,7 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(result.Err).ToNot(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Failed))
 	})
@@ -98,7 +98,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -109,7 +109,7 @@ var _ = Describe("Client", func() {
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
 	})
@@ -120,7 +120,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -131,11 +131,11 @@ var _ = Describe("Client", func() {
 		d.SetJobQueue(key, nil, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
 
-		result = d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		result = d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Unavailable))
 	})
@@ -153,11 +153,11 @@ var _ = Describe("Client", func() {
 		d := deployer.GetClient(context.TODO(), klogr.New(), c, 10)
 		defer d.ClearInternalStruct()
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Unavailable))
 
-		result = d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		result = d.GetResult(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Unavailable))
 	})
@@ -174,7 +174,7 @@ var _ = Describe("Client", func() {
 		defer cancel()
 		d := deployer.GetClient(context.TODO(), klogr.New(), c, 10)
 
-		err := d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup, nil, nil, deployer.Options{})
+		err := d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup, nil, nil, deployer.Options{})
 		Expect(err).ToNot(BeNil())
 	})
 
@@ -194,11 +194,11 @@ var _ = Describe("Client", func() {
 		err := d.RegisterFeatureID(featureID)
 		Expect(err).To(BeNil())
 
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		d.SetDirty([]string{key})
 		Expect(len(d.GetDirty())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi,
+		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi,
 			cleanup, nil, nil, deployer.Options{})
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
@@ -222,7 +222,7 @@ var _ = Describe("Client", func() {
 		err := d.RegisterFeatureID(featureID)
 		Expect(err).To(BeNil())
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup, nil, nil, deployer.Options{})
+		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup, nil, nil, deployer.Options{})
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
 		Expect(len(d.GetInProgress())).To(Equal(0))
@@ -235,7 +235,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -249,7 +249,7 @@ var _ = Describe("Client", func() {
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos,
+		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos,
 			cleanup, nil, nil, deployer.Options{})
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
@@ -263,7 +263,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -278,7 +278,7 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi,
+		err = d.Deploy(ctx, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi,
 			cleanup, nil, nil, deployer.Options{})
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
@@ -293,7 +293,7 @@ var _ = Describe("Client", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		_, cancel := context.WithCancel(context.TODO())
@@ -317,7 +317,7 @@ var _ = Describe("Client", func() {
 		d.SetJobQueue(key, nil, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		d.CleanupEntries(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		d.CleanupEntries(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(len(d.GetDirty())).To(Equal(0))
 		Expect(len(d.GetInProgress())).To(Equal(1))
 		Expect(len(d.GetJobQueue())).To(Equal(0))

--- a/lib/deployer/fake/client.go
+++ b/lib/deployer/fake/client.go
@@ -22,8 +22,9 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
+
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 )
 
 // fakeDeployer is a fake provider that implements the DeployerInterface
@@ -63,7 +64,7 @@ func (d *fakeDeployer) RegisterFeatureID(
 func (d *fakeDeployer) Deploy(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 	f deployer.RequestHandler,
 	m deployer.MetricHandler,
@@ -83,7 +84,7 @@ func (d *fakeDeployer) Deploy(
 func (d *fakeDeployer) GetResult(
 	ctx context.Context,
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 ) deployer.Result {
 
@@ -106,7 +107,7 @@ func (d *fakeDeployer) GetResult(
 
 func (d *fakeDeployer) IsInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 ) bool {
 
@@ -121,7 +122,7 @@ func (d *fakeDeployer) IsInProgress(
 
 func (d *fakeDeployer) CleanupEntries(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool) {
 
 	key := deployer.GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)
@@ -133,7 +134,7 @@ func (d *fakeDeployer) CleanupEntries(
 // StoreResult store request result
 func (d *fakeDeployer) StoreResult(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 	err error,
 ) {
@@ -145,7 +146,7 @@ func (d *fakeDeployer) StoreResult(
 // StoreInProgress marks request as in progress
 func (d *fakeDeployer) StoreInProgress(
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool,
 ) {
 

--- a/lib/deployer/request_interface.go
+++ b/lib/deployer/request_interface.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 )
 
 const (
@@ -63,11 +63,11 @@ type Result struct {
 
 type RequestHandler func(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, featureID string,
-	clusterType sveltosv1.ClusterType, o Options, logger logr.Logger) error
+	clusterType sveltosv1alpha1.ClusterType, o Options, logger logr.Logger) error
 
 type MetricHandler func(elapsed time.Duration,
 	clusterNamespace, clusterName, featureID string,
-	clusterType sveltosv1.ClusterType, logger logr.Logger)
+	clusterType sveltosv1alpha1.ClusterType, logger logr.Logger)
 
 type DeployerInterface interface {
 	// RegisterFeatureID allows registering a feature ID.
@@ -89,7 +89,7 @@ type DeployerInterface interface {
 	Deploy(
 		ctx context.Context,
 		clusterNamespace, clusterName, applicant, featureID string,
-		clusterType sveltosv1.ClusterType,
+		clusterType sveltosv1alpha1.ClusterType,
 		cleanup bool,
 		f RequestHandler,
 		m MetricHandler,
@@ -102,7 +102,7 @@ type DeployerInterface interface {
 	// removed is currently in progress.
 	IsInProgress(
 		clusterNamespace, clusterName, applicant, featureID string,
-		clusterType sveltosv1.ClusterType,
+		clusterType sveltosv1alpha1.ClusterType,
 		cleanup bool,
 	) bool
 
@@ -110,12 +110,12 @@ type DeployerInterface interface {
 	GetResult(
 		ctx context.Context,
 		clusterNamespace, clusterName, applicant, featureID string,
-		clusterType sveltosv1.ClusterType,
+		clusterType sveltosv1alpha1.ClusterType,
 		cleanup bool,
 	) Result
 
 	// CleanupEntries removes any entry (from any internal data structure) for
 	// given feature
 	CleanupEntries(clusterNamespace, clusterName, applicant, featureID string,
-		clusterType sveltosv1.ClusterType, cleanup bool)
+		clusterType sveltosv1alpha1.ClusterType, cleanup bool)
 }

--- a/lib/deployer/utils.go
+++ b/lib/deployer/utils.go
@@ -188,7 +188,7 @@ func AddOwnerReference(object *unstructured.Unstructured, owner client.Object) {
 // reference same ConfigMap. This means a policy contained in a ConfigMap is deployed in a Cluster
 // because of different SveltosResources. When cleaning up, a policy can be removed only if no more
 // SveltosResources are listed as OwnerReferences.
-func RemoveOwnerReference(object *unstructured.Unstructured, owner client.Object) {
+func RemoveOwnerReference(object, owner client.Object) {
 	onwerReferences := object.GetOwnerReferences()
 	if onwerReferences == nil {
 		return
@@ -211,7 +211,7 @@ func RemoveOwnerReference(object *unstructured.Unstructured, owner client.Object
 }
 
 // IsOnlyOwnerReference returns true if clusterprofile is the only ownerreference for object
-func IsOnlyOwnerReference(object *unstructured.Unstructured, owner client.Object) bool {
+func IsOnlyOwnerReference(object, owner client.Object) bool {
 	onwerReferences := object.GetOwnerReferences()
 	if onwerReferences == nil {
 		return false
@@ -226,4 +226,26 @@ func IsOnlyOwnerReference(object *unstructured.Unstructured, owner client.Object
 	ref := &onwerReferences[0]
 	return ref.Kind == kind &&
 		ref.Name == owner.GetName()
+}
+
+// IsOwnerReference returns true is owner is one of the OwnerReferences
+// for object
+func IsOwnerReference(object, owner client.Object) bool {
+	onwerReferences := object.GetOwnerReferences()
+	if onwerReferences == nil {
+		return false
+	}
+
+	kind := owner.GetObjectKind().GroupVersionKind().Kind
+
+	for i := range onwerReferences {
+		ref := &onwerReferences[i]
+		if ref.Kind == kind &&
+			ref.Name == owner.GetName() {
+
+			return true
+		}
+	}
+
+	return false
 }

--- a/lib/deployer/utils_test.go
+++ b/lib/deployer/utils_test.go
@@ -152,4 +152,34 @@ var _ = Describe("Client", func() {
 		deployer.AddOwnerReference(policy, roleRequest2)
 		Expect(deployer.IsOnlyOwnerReference(policy, roleRequest)).To(BeFalse())
 	})
+
+	It("IsOwnerReference returns true when owner is present", func() {
+		roleRequest := &libsveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(testEnv.Scheme(), roleRequest)).To(Succeed())
+
+		roleRequest2 := &libsveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(testEnv.Scheme(), roleRequest2)).To(Succeed())
+
+		policy, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
+		Expect(err).To(BeNil())
+		Expect(policy.GetKind()).To(Equal("ClusterRole"))
+
+		Expect(addTypeInformationToObject(testEnv.Scheme(), roleRequest)).To(Succeed())
+
+		deployer.AddOwnerReference(policy, roleRequest)
+
+		Expect(deployer.IsOwnerReference(policy, roleRequest)).To(BeTrue())
+		Expect(deployer.IsOwnerReference(policy, roleRequest2)).To(BeFalse())
+
+		deployer.AddOwnerReference(policy, roleRequest2)
+		Expect(deployer.IsOwnerReference(policy, roleRequest)).To(BeTrue())
+	})
 })

--- a/lib/deployer/worker.go
+++ b/lib/deployer/worker.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
@@ -92,7 +92,7 @@ func (d *deployer) startWorkloadWorkers(ctx context.Context, numOfWorker int, lo
 // - clusterNamespace and clusterName which are the namespace/name of the
 // cluster where feature needs to be deployed;
 // - featureID is a unique identifier for the feature that needs to be deployed.
-func GetKey(clusterNamespace, clusterName, applicant, featureID string, clusterType sveltosv1.ClusterType, cleanup bool) string {
+func GetKey(clusterNamespace, clusterName, applicant, featureID string, clusterType sveltosv1alpha1.ClusterType, cleanup bool) string {
 	return clusterNamespace + separator + clusterName + separator + string(clusterType) + separator +
 		applicant + separator + featureID + separator + strconv.FormatBool(cleanup)
 }
@@ -114,7 +114,7 @@ func getClusterFromKey(key string) (namespace, name string, err error) {
 
 // getClusterTypeFromKey given a unique request key, returns:
 // - clusterType of the cluster where features need to be deployed
-func getClusterTypeFromKey(key string) (clusterType sveltosv1.ClusterType, err error) {
+func getClusterTypeFromKey(key string) (clusterType sveltosv1alpha1.ClusterType, err error) {
 	info := strings.Split(key, separator)
 	const length = 6
 	if len(info) != length {
@@ -122,7 +122,7 @@ func getClusterTypeFromKey(key string) (clusterType sveltosv1.ClusterType, err e
 		return
 	}
 	currentClusterType := info[2]
-	clusterType = sveltosv1.ClusterType(currentClusterType)
+	clusterType = sveltosv1alpha1.ClusterType(currentClusterType)
 	return
 }
 
@@ -262,7 +262,7 @@ func storeResult(d *deployer, key string, err error, handler RequestHandler, met
 // If result is available it returns the result.
 // If request is still queued, responseParams is nil and an error is nil.
 // If result is not available and request is neither queued nor already processed, it returns an error to indicate that.
-func getRequestStatus(d *deployer, clusterNamespace, clusterName, applicant, featureID string, clusterType sveltosv1.ClusterType,
+func getRequestStatus(d *deployer, clusterNamespace, clusterName, applicant, featureID string, clusterType sveltosv1alpha1.ClusterType,
 	cleanup bool) (*responseParams, error) {
 
 	key := GetKey(clusterNamespace, clusterName, applicant, featureID, clusterType, cleanup)

--- a/lib/deployer/worker_test.go
+++ b/lib/deployer/worker_test.go
@@ -28,14 +28,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 )
 
 var messages chan string
 
 func writeToChannelHandler(ctx context.Context, c client.Client,
-	namespace, name, applicant, featureID string, clusterType sveltosv1.ClusterType,
+	namespace, name, applicant, featureID string, clusterType sveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	By("writeToChannelHandler: writing to channel")
@@ -45,14 +45,14 @@ func writeToChannelHandler(ctx context.Context, c client.Client,
 
 func metricHandler(elapsed time.Duration,
 	clusterNamespace, clusterName, featureID string,
-	clusterType sveltosv1.ClusterType,
+	clusterType sveltosv1alpha1.ClusterType,
 	logger logr.Logger) {
 
 	By("metricHandler: storing metrics")
 }
 
 func doNothingHandler(ctx context.Context, c client.Client,
-	namespace, name, applicant, featureID string, clusterType sveltosv1.ClusterType,
+	namespace, name, applicant, featureID string, clusterType sveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	return nil
@@ -65,7 +65,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		outNs, outName, err := deployer.GetClusterFromKey(key)
 		Expect(err).To(BeNil())
@@ -86,7 +86,7 @@ var _ = Describe("Worker", func() {
 		applicant := ""
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, false)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, false)
 
 		outNs, outName, err := deployer.GetClusterFromKey(key)
 		Expect(err).To(BeNil())
@@ -125,7 +125,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -143,7 +143,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -166,13 +166,13 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 
 		r := map[string]error{key: nil}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
@@ -188,13 +188,13 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		r := map[string]error{key: fmt.Errorf("failed to deploy")}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseFailed(resp)).To(BeTrue())
@@ -210,12 +210,12 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeSveltos, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeSveltos, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -230,12 +230,12 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := false
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 
 		d.SetJobQueue(key, nil, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -251,7 +251,7 @@ var _ = Describe("Worker", func() {
 		applicant := randomString()
 		featureID := randomString()
 		cleanup := true
-		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		key := deployer.GetKey(ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		d.SetJobQueue(key, writeToChannelHandler, metricHandler)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 		messages = make(chan string)
@@ -271,7 +271,7 @@ var _ = Describe("Worker", func() {
 			return gotResult
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1.ClusterTypeCapi, cleanup)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, sveltosv1alpha1.ClusterTypeCapi, cleanup)
 		Expect(err).To(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
 	})

--- a/lib/logsettings/logsettings.go
+++ b/lib/logsettings/logsettings.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 )
 
 // Following are log severity levels to be used by sveltos services
@@ -68,7 +68,7 @@ type LogSetter struct {
 	verboseValue string
 
 	// Component registered
-	component sveltosv1.Component
+	component sveltosv1alpha1.Component
 
 	config *rest.Config
 }
@@ -78,7 +78,7 @@ var (
 	once     sync.Once
 )
 
-func newInstance(component sveltosv1.Component, config *rest.Config, logger logr.Logger) *LogSetter {
+func newInstance(component sveltosv1alpha1.Component, config *rest.Config, logger logr.Logger) *LogSetter {
 	once.Do(func() {
 		logger.Info("Creating LogSetter instance")
 		instance = &LogSetter{
@@ -127,7 +127,7 @@ func GetInstance() *LogSetter {
 // severity set for affected component(s).
 func RegisterForLogSettings(
 	ctx context.Context,
-	component sveltosv1.Component,
+	component sveltosv1alpha1.Component,
 	logger logr.Logger,
 	config *rest.Config,
 ) *LogSetter {
@@ -172,7 +172,7 @@ func runDebuggingConfigurationInformer(
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			instance.logger.Info("got add notification for DebuggingConfiguration")
-			d := &sveltosv1.DebuggingConfiguration{}
+			d := &sveltosv1alpha1.DebuggingConfiguration{}
 			err := runtime.DefaultUnstructuredConverter.
 				FromUnstructured(obj.(*unstructured.Unstructured).UnstructuredContent(), d)
 			if err != nil {
@@ -193,7 +193,7 @@ func runDebuggingConfigurationInformer(
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			instance.logger.Info("got update notification for DebuggingConfiguration")
-			d := &sveltosv1.DebuggingConfiguration{}
+			d := &sveltosv1alpha1.DebuggingConfiguration{}
 			err := runtime.DefaultUnstructuredConverter.
 				FromUnstructured(newObj.(*unstructured.Unstructured).UnstructuredContent(), d)
 			if err != nil {
@@ -209,25 +209,25 @@ func runDebuggingConfigurationInformer(
 
 // UpdateLogLevel updates log severity
 func UpdateLogLevel(
-	d *sveltosv1.DebuggingConfiguration,
+	d *sveltosv1alpha1.DebuggingConfiguration,
 ) {
 
 	found := false
 	for _, c := range d.Spec.Configuration {
 		if instance.component == c.Component {
-			if c.LogLevel == sveltosv1.LogLevelVerbose {
+			if c.LogLevel == sveltosv1alpha1.LogLevelVerbose {
 				found = true
 				instance.logger.Info("Setting log severity to verbose", "verbose", instance.verboseValue)
 				if err := flag.Lookup("v").Value.Set(instance.verboseValue); err != nil {
 					instance.logger.Error(err, "unable to set log level")
 				}
-			} else if c.LogLevel == sveltosv1.LogLevelDebug {
+			} else if c.LogLevel == sveltosv1alpha1.LogLevelDebug {
 				found = true
 				instance.logger.Info("Setting log severity to debug", "debug", instance.debugValue)
 				if err := flag.Lookup("v").Value.Set(instance.debugValue); err != nil {
 					instance.logger.Error(err, "unable to set log level")
 				}
-			} else if c.LogLevel == sveltosv1.LogLevelInfo {
+			} else if c.LogLevel == sveltosv1alpha1.LogLevelInfo {
 				found = true
 				instance.logger.Info("Setting log severity to info", "info", instance.infoValue)
 				if err := flag.Lookup("v").Value.Set(instance.infoValue); err != nil {

--- a/lib/logsettings/logsettings_suite_test.go
+++ b/lib/logsettings/logsettings_suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).ToNot(BeNil())
 
 	Expect(v1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sveltosv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(sveltosv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	klog.InitFlags(nil)
 	Expect(flag.Lookup("v").Value.Set("0")).To(BeNil())
 	instance = logsettings.RegisterForLogSettings(context.TODO(),
-		sveltosv1.ComponentSveltosManager, klogr.New(), cfg)
+		sveltosv1alpha1.ComponentSveltosManager, klogr.New(), cfg)
 })
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/lib/logsettings/logsettings_test.go
+++ b/lib/logsettings/logsettings_test.go
@@ -25,19 +25,19 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	sveltosv1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
 var _ = Describe("Logsettings", func() {
 	It("Should change log level appropriately", func() {
-		conf := &sveltosv1.DebuggingConfiguration{
+		conf := &sveltosv1alpha1.DebuggingConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "default",
 			},
-			Spec: sveltosv1.DebuggingConfigurationSpec{
-				Configuration: []sveltosv1.ComponentConfiguration{
-					{Component: sveltosv1.ComponentSveltosManager, LogLevel: sveltosv1.LogLevelDebug},
+			Spec: sveltosv1alpha1.DebuggingConfigurationSpec{
+				Configuration: []sveltosv1alpha1.ComponentConfiguration{
+					{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
 				},
 			},
 		}
@@ -47,8 +47,8 @@ var _ = Describe("Logsettings", func() {
 		Expect(f).ToNot(BeNil())
 		Expect(f.Value.String()).To(Equal(strconv.Itoa(logsettings.LogDebug)))
 
-		conf.Spec.Configuration = []sveltosv1.ComponentConfiguration{
-			{Component: sveltosv1.ComponentSveltosManager, LogLevel: sveltosv1.LogLevelInfo},
+		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
+			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -56,8 +56,8 @@ var _ = Describe("Logsettings", func() {
 		Expect(f).ToNot(BeNil())
 		Expect(f.Value.String()).To(Equal(strconv.Itoa(logsettings.LogInfo)))
 
-		conf.Spec.Configuration = []sveltosv1.ComponentConfiguration{
-			{Component: sveltosv1.ComponentSveltosManager, LogLevel: sveltosv1.LogLevelVerbose},
+		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
+			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelVerbose},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -67,8 +67,8 @@ var _ = Describe("Logsettings", func() {
 
 		newDebugValue := 8
 		instance.SetDebugValue(newDebugValue)
-		conf.Spec.Configuration = []sveltosv1.ComponentConfiguration{
-			{Component: sveltosv1.ComponentSveltosManager, LogLevel: sveltosv1.LogLevelDebug},
+		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
+			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -78,8 +78,8 @@ var _ = Describe("Logsettings", func() {
 
 		newInfoValue := 5
 		instance.SetInfoValue(newInfoValue)
-		conf.Spec.Configuration = []sveltosv1.ComponentConfiguration{
-			{Component: sveltosv1.ComponentSveltosManager, LogLevel: sveltosv1.LogLevelInfo},
+		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
+			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
 		}
 
 		logsettings.UpdateLogLevel(conf)

--- a/lib/roles/roles_suite_test.go
+++ b/lib/roles/roles_suite_test.go
@@ -1,14 +1,18 @@
 package roles_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 )
 
 var (
@@ -38,5 +42,29 @@ func setupScheme() (*runtime.Scheme, error) {
 	if err := clientgoscheme.AddToScheme(s); err != nil {
 		return nil, err
 	}
+	if err := sveltosv1alpha1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+
 	return s, nil
+}
+
+func addTypeInformationToObject(scheme *runtime.Scheme, obj client.Object) error {
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
+	}
+
+	for _, gvk := range gvks {
+		if gvk.Kind == "" {
+			continue
+		}
+		if gvk.Version == "" || gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
+	}
+
+	return nil
 }

--- a/lib/roles/roles_test.go
+++ b/lib/roles/roles_test.go
@@ -13,7 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/crd"
 	"github.com/projectsveltos/libsveltos/lib/roles"
+	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var _ = Describe("Roles", func() {
@@ -84,9 +86,19 @@ var _ = Describe("Roles", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
+		roleRequestCRD, err := utils.GetUnstructured(crd.GetRoleRequestCRDYAML())
+		Expect(err).To(BeNil())
+		Expect(c.Create(context.TODO(), roleRequestCRD)).To(Succeed())
+
+		roleRequest := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+
 		secret, err := roles.CreateSecret(context.TODO(), c,
 			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos,
-			[]byte(randomString()))
+			[]byte(randomString()), roleRequest)
 		Expect(err).To(BeNil())
 		Expect(secret).ToNot(BeNil())
 		Expect(secret.Namespace).To(Equal(clusterNamespace))
@@ -123,11 +135,17 @@ var _ = Describe("Roles", func() {
 
 		initObjects := []client.Object{secret}
 
+		roleRequest := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		currentSecret, err := roles.CreateSecret(context.TODO(), c,
 			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos,
-			kubeconfig)
+			kubeconfig, roleRequest)
 		Expect(err).To(BeNil())
 		Expect(currentSecret).ToNot(BeNil())
 		Expect(currentSecret.Namespace).To(Equal(clusterNamespace))
@@ -156,8 +174,15 @@ var _ = Describe("Roles", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
+		roleRequest := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, roleRequest)).To(Succeed())
+
 		err := roles.DeleteSecret(context.TODO(), c,
-			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos, roleRequest)
 		Expect(err).To(BeNil())
 	})
 
@@ -165,6 +190,13 @@ var _ = Describe("Roles", func() {
 		clusterNamespace := randomString()
 		clusterName := randomString()
 		serviceaccountName := randomString()
+
+		roleRequest := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, roleRequest)).To(Succeed())
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -174,6 +206,9 @@ var _ = Describe("Roles", func() {
 					roles.ClusterNameLabel:        clusterName,
 					roles.ServiceAccountNameLabel: serviceaccountName,
 				},
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: roleRequest.APIVersion, Kind: sveltosv1alpha1.RoleRequestKind, Name: roleRequest.Name},
+				},
 			},
 		}
 
@@ -182,7 +217,7 @@ var _ = Describe("Roles", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		err := roles.DeleteSecret(context.TODO(), c,
-			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos)
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos, roleRequest)
 		Expect(err).To(BeNil())
 
 		listOptions := []client.ListOption{
@@ -196,5 +231,114 @@ var _ = Describe("Roles", func() {
 		secretList := &corev1.SecretList{}
 		Expect(c.List(context.TODO(), secretList, listOptions...)).To(Succeed())
 		Expect(len(secretList.Items)).To(BeZero())
+	})
+
+	It("DeleteSecret does not delete existing secret with multiple owners", func() {
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		serviceaccountName := randomString()
+
+		roleRequest1 := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, roleRequest1)).To(Succeed())
+
+		roleRequest2 := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, roleRequest2)).To(Succeed())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      randomString(),
+				Labels: map[string]string{
+					roles.ClusterNameLabel:        clusterName,
+					roles.ServiceAccountNameLabel: serviceaccountName,
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: roleRequest1.APIVersion, Kind: sveltosv1alpha1.RoleRequestKind, Name: roleRequest1.Name},
+					{APIVersion: roleRequest2.APIVersion, Kind: sveltosv1alpha1.RoleRequestKind, Name: roleRequest2.Name},
+				},
+			},
+		}
+
+		initObjects := []client.Object{secret}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		err := roles.DeleteSecret(context.TODO(), c,
+			clusterNamespace, clusterName, serviceaccountName, sveltosv1alpha1.ClusterTypeSveltos, roleRequest1)
+		Expect(err).To(BeNil())
+
+		listOptions := []client.ListOption{
+			client.InNamespace(clusterNamespace),
+			client.MatchingLabels{
+				roles.ClusterNameLabel:        clusterName,
+				roles.ServiceAccountNameLabel: serviceaccountName,
+			},
+		}
+
+		secretList := &corev1.SecretList{}
+		Expect(c.List(context.TODO(), secretList, listOptions...)).To(Succeed())
+		Expect(len(secretList.Items)).To(Equal(1))
+		Expect(secretList.Items[0].OwnerReferences).ToNot(BeNil())
+		Expect(len(secretList.Items[0].OwnerReferences)).To(Equal(1))
+		Expect(secretList.Items[0].OwnerReferences[0].Name).To(Equal(roleRequest2.Name))
+	})
+
+	It("ListSecretForOwnner returns all secret for which owner is one of the OnwerReferences", func() {
+		roleRequest1 := &sveltosv1alpha1.RoleRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, roleRequest1)).To(Succeed())
+
+		secret1 := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+				Labels: map[string]string{
+					sveltosv1alpha1.RoleRequestLabel: "ok",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: roleRequest1.APIVersion, Kind: sveltosv1alpha1.RoleRequestKind, Name: roleRequest1.Name},
+				},
+			},
+		}
+
+		secret2 := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: roleRequest1.APIVersion, Kind: sveltosv1alpha1.RoleRequestKind, Name: roleRequest1.Name},
+				},
+			},
+		}
+
+		secret3 := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+				Labels: map[string]string{
+					sveltosv1alpha1.RoleRequestLabel: "ok",
+				},
+			},
+		}
+
+		initObjects := []client.Object{secret1, secret2, secret3}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+		list, err := roles.ListSecretForOwnner(context.TODO(), c, roleRequest1)
+		Expect(err).To(BeNil())
+		Expect(len(list)).To(Equal(1))
+		Expect(list[0].Name).To(Equal(secret1.Name))
+		Expect(list[0].Namespace).To(Equal(secret1.Namespace))
 	})
 })


### PR DESCRIPTION
A Secret containing Kubeconfig for a pair admin/cluster can be created because of multiple reasons. So add ownerReferences for ref counting purposes.