### PR TITLE
PolicyRef namespace

### DIFF
--- a/api/v1alpha1/policyref.go
+++ b/api/v1alpha1/policyref.go
@@ -20,7 +20,8 @@ package v1alpha1
 // to deploy in matching Clusters.
 type PolicyRef struct {
 	// Namespace of the referenced resource.
-	// +kubebuilder:validation:MinLength=1
+	// Namespace can be left empty. In such a case, namespace will
+	// be implicit set to cluster's namespace.
 	Namespace string `json:"namespace"`
 
 	// Name of the rreferenced resource.

--- a/config/crd/bases/lib.projectsveltos.io_rolerequests.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_rolerequests.yaml
@@ -62,8 +62,9 @@ spec:
                       minLength: 1
                       type: string
                     namespace:
-                      description: Namespace of the referenced resource.
-                      minLength: 1
+                      description: Namespace of the referenced resource. Namespace
+                        can be left empty. In such a case, namespace will be implicit
+                        set to cluster's namespace.
                       type: string
                   required:
                   - kind

--- a/lib/crd/rolerequests.go
+++ b/lib/crd/rolerequests.go
@@ -81,8 +81,9 @@ spec:
                       minLength: 1
                       type: string
                     namespace:
-                      description: Namespace of the referenced resource.
-                      minLength: 1
+                      description: Namespace of the referenced resource. Namespace
+                        can be left empty. In such a case, namespace will be implicit
+                        set to cluster's namespace.
                       type: string
                   required:
                   - kind


### PR DESCRIPTION
It is not required to set namespace anymore when referencing a ConfigMap or Secret.
If namespace is set, it uniquely identifies a ConfigMap/Secret. If namespace is not set, at the time of deployment, the namespace will be implicity set to cluster namespace.