### PR TITLE
Add name to LivenessCheck and Notification

### DIFF
--- a/api/v1alpha1/clusterhealthcheck_type.go
+++ b/api/v1alpha1/clusterhealthcheck_type.go
@@ -100,6 +100,10 @@ const (
 )
 
 type LivenessCheck struct {
+	// Name of the liveness check.
+	// Must be a DNS_LABEL and unique within the ClusterHealthCheck.
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+
 	// Type specifies the type of liveness
 	Type LivenessType `json:"type"`
 
@@ -119,6 +123,10 @@ const (
 )
 
 type Notification struct {
+	// Name of the notification check.
+	// Must be a DNS_LABEL and unique within the ClusterHealthCheck.
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+
 	// NotificationType specifies the type of notification
 	Type NotificationType `json:"type"`
 
@@ -135,9 +143,13 @@ type ClusterHealthCheckSpec struct {
 
 	// LivenessChecks is a list of source of liveness checks to evaluate.
 	// Anytime one of those changes, notifications will be sent
+	// +patchMergeKey=name
+	// +patchStrategy=merge,retainKeys
 	LivenessChecks []LivenessCheck `json:"livenessChecks"`
 
 	// Notification is a list of source of events to evaluate.
+	// +patchMergeKey=name
+	// +patchStrategy=merge,retainKeys
 	Notifications []Notification `json:"notifications"`
 }
 

--- a/config/crd/bases/lib.projectsveltos.io_clusterhealthchecks.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_clusterhealthchecks.yaml
@@ -83,12 +83,17 @@ spec:
                           description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                           type: string
                       type: object
+                    name:
+                      description: Name of the liveness check. Must be a DNS_LABEL
+                        and unique within the ClusterHealthCheck.
+                      type: string
                     type:
                       description: Type specifies the type of liveness
                       enum:
                       - Addons
                       type: string
                   required:
+                  - name
                   - type
                   type: object
                 type: array
@@ -96,6 +101,10 @@ spec:
                 description: Notification is a list of source of events to evaluate.
                 items:
                   properties:
+                    name:
+                      description: Name of the notification check. Must be a DNS_LABEL
+                        and unique within the ClusterHealthCheck.
+                      type: string
                     notificationRef:
                       description: NotificationRef is a reference to a notification-specific
                         resource that holds the details for the notification.
@@ -140,6 +149,7 @@ spec:
                       - KubernetesEvent
                       type: string
                   required:
+                  - name
                   - type
                   type: object
                 type: array

--- a/lib/crd/clusterhealthchecks.go
+++ b/lib/crd/clusterhealthchecks.go
@@ -102,12 +102,17 @@ spec:
                           description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                           type: string
                       type: object
+                    name:
+                      description: Name of the liveness check. Must be a DNS_LABEL
+                        and unique within the ClusterHealthCheck.
+                      type: string
                     type:
                       description: Type specifies the type of liveness
                       enum:
                       - Addons
                       type: string
                   required:
+                  - name
                   - type
                   type: object
                 type: array
@@ -115,6 +120,10 @@ spec:
                 description: Notification is a list of source of events to evaluate.
                 items:
                   properties:
+                    name:
+                      description: Name of the notification check. Must be a DNS_LABEL
+                        and unique within the ClusterHealthCheck.
+                      type: string
                     notificationRef:
                       description: NotificationRef is a reference to a notification-specific
                         resource that holds the details for the notification.
@@ -159,6 +168,7 @@ spec:
                       - KubernetesEvent
                       type: string
                   required:
+                  - name
                   - type
                   type: object
                 type: array


### PR DESCRIPTION
Name must be unique among all LivenessChecks in a ClusterHealthChecks Name must be unique among all Notifications in a ClusterHealthCheck