### PR TITLE
Add slack notification type

### DIFF
--- a/api/v1alpha1/clusterhealthcheck_type.go
+++ b/api/v1alpha1/clusterhealthcheck_type.go
@@ -31,6 +31,14 @@ const (
 	FeatureClusterHealthCheck = "ClusterHealthCheck"
 )
 
+// Slack constant
+// To have Sveltos sends a slack notification, create a Secret of type "addons.projectsveltos.io/cluster-profile"
+// In the data section set both slack token and slack channel id
+const (
+	SlackToken     = "SLACK_TOKEN"
+	SlackChannelID = "SLACK_CHANNEL_ID"
+)
+
 // ConditionSeverity expresses the severity of a Condition Type failing.
 type ConditionSeverity string
 
@@ -118,12 +126,15 @@ type LivenessCheck struct {
 }
 
 // NotificationType specifies different type of notifications
-// +kubebuilder:validation:Enum:=KubernetesEvent
+// +kubebuilder:validation:Enum:=KubernetesEvent;Slack
 type NotificationType string
 
 const (
 	// NotificationTypeKubernetesEvent refers to generating a Kubernetes event
 	NotificationTypeKubernetesEvent = NotificationType("KubernetesEvent")
+
+	// NotificationTypeSlack refers to generating a Slack message
+	NotificationTypeSlack = NotificationType("Slack")
 )
 
 type Notification struct {

--- a/config/crd/bases/lib.projectsveltos.io_clusterhealthchecks.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_clusterhealthchecks.yaml
@@ -147,6 +147,7 @@ spec:
                       description: NotificationType specifies the type of notification
                       enum:
                       - KubernetesEvent
+                      - Slack
                       type: string
                   required:
                   - name

--- a/lib/crd/clusterhealthchecks.go
+++ b/lib/crd/clusterhealthchecks.go
@@ -166,6 +166,7 @@ spec:
                       description: NotificationType specifies the type of notification
                       enum:
                       - KubernetesEvent
+                      - Slack
                       type: string
                   required:
                   - name


### PR DESCRIPTION
This type of notification will send a slack message on the specified channel when clusterHealthCheck liveness checks change