### PR TITLE
ClusterHealthCheck feature

### DIFF
--- a/api/v1alpha1/clusterhealthcheck_type.go
+++ b/api/v1alpha1/clusterhealthcheck_type.go
@@ -28,7 +28,11 @@ const (
 
 	ClusterHealthCheckKind = "ClusterHealthCheck"
 
-	FeatureClusterHealthCheck = "ClusterHealthCheck"
+	// Used to deploy ClusterHealthCheck resources in managed nodes
+	FeatureClusterHealthCheckDeployment = "ClusterHealthCheck-Deployment"
+
+	// Used to evaluate ClusterHealthCheck liveness checks and send notifications
+	FeatureClusterHealthCheckEvaluation = "ClusterHealthCheck-Evaluation"
 )
 
 // Slack constant


### PR DESCRIPTION
Differentiate between deploying/removing resources in managed clusters vs evaluating liveness checks and sending notifications