### PR TITLE
Define DeployedBySveltosAnnotation

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -23,6 +23,15 @@ import (
 )
 
 const (
+	// DeployedBySveltosAnnotation is an annotation Sveltos adds to
+	// EventSource/HealthCheck/Classifier/ResourceSummary instances deployed
+	// by sveltos in managed clusters. Those resources, once deployed in a
+	// managed cluster, are evaluated by sveltos services (sveltos-agent and
+	// drift-detection-manager) running in the managed cluster
+	DeployedBySveltosAnnotation = "projectsveltos.io/deployed-by-sveltos"
+)
+
+const (
 	// ServiceAccountNameLabel can be set on various Sveltos resources (ClusterProfile/EventSource/...)
 	// to indicate which admin (represented by a ServiceAccount) is creating it (service account name).
 	// ServiceAccountNameLabel used along with RoleRequest is Sveltos solution for multi tenancy.


### PR DESCRIPTION
Sveltos deploys in managed clusters:
1. EventSource
2. HealthCheck
3. Classifier
4. ResourceSummary

instances.
Once deployed in a managed cluster, such instances are evaluated by sveltos services running in the managed cluster (sveltos-agent and drift-detection-manager).

Sometimes management cluster might be in turn a managed cluster. Meaning the management clusters is deploying add-ons in managed clusters, but also there is another cluster with Sveltos managing the management cluster (in this case, management cluster will be a SveltosCluster in the other cluster).

In this scenario, in the management cluster there are two different types of EventSource/HealthCheck/Classifier/ResourceSummaries instances:
1. the instances defined in the management cluster that need to be deployed and evaluated in the managed clusters;
2. the instances defined in the other cluster which are meant to be evaluated in the management cluster.

This annotation is used in order for sveltos-agent and drift-detection-manager to understand which instances to process and which to ignore:
1. an instance deployed by sveltos will have this annotation and needs to be evaluated;
2. an instance defined by platform/tenant admin won't have this annotation and it will not be evaluated (it is there just to be pushed and evaluated in managed clusters).