### PR TITLE
Rename addon-manager component

### DIFF
--- a/api/v1alpha1/debuggingconfiguration_types.go
+++ b/api/v1alpha1/debuggingconfiguration_types.go
@@ -42,13 +42,13 @@ const (
 )
 
 //nolint:lll // kubebuilder marker
-// +kubebuilder:validation:Enum:=SveltosManager;AddonConstraintManager;Classifier;ClassifierAgent;SveltosClusterManager;DriftDetectionManager;AccessManager;HealthCheckManager;EventManager
+// +kubebuilder:validation:Enum:=AddonManager;AddonConstraintManager;Classifier;ClassifierAgent;SveltosClusterManager;DriftDetectionManager;AccessManager;HealthCheckManager;EventManager
 
 type Component string
 
 const (
-	// ComponentSveltosManager is the addon-manager pod
-	ComponentSveltosManager = Component("SveltosManager")
+	// ComponentAddonManager is the addon-manager pod
+	ComponentAddonManager = Component("AddonManager")
 
 	// AddonConstraintManager is the addon-constraint pod
 	ComponentAddonConstraintManager = Component("AddonConstraintManager")

--- a/config/crd/bases/lib.projectsveltos.io_debuggingconfigurations.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_debuggingconfigurations.yaml
@@ -47,7 +47,7 @@ spec:
                       description: Component indicates which Sveltos component the
                         configuration applies to.
                       enum:
-                      - SveltosManager
+                      - AddonManager
                       - AddonConstraintManager
                       - Classifier
                       - ClassifierAgent

--- a/lib/crd/debuggingconfigurations.go
+++ b/lib/crd/debuggingconfigurations.go
@@ -66,7 +66,7 @@ spec:
                       description: Component indicates which Sveltos component the
                         configuration applies to.
                       enum:
-                      - SveltosManager
+                      - AddonManager
                       - AddonConstraintManager
                       - Classifier
                       - ClassifierAgent

--- a/lib/logsettings/logsettings_suite_test.go
+++ b/lib/logsettings/logsettings_suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	klog.InitFlags(nil)
 	Expect(flag.Lookup("v").Value.Set("0")).To(BeNil())
 	instance = logsettings.RegisterForLogSettings(context.TODO(),
-		sveltosv1alpha1.ComponentSveltosManager, klogr.New(), cfg)
+		sveltosv1alpha1.ComponentAddonManager, klogr.New(), cfg)
 })
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/lib/logsettings/logsettings_test.go
+++ b/lib/logsettings/logsettings_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Logsettings", func() {
 			},
 			Spec: sveltosv1alpha1.DebuggingConfigurationSpec{
 				Configuration: []sveltosv1alpha1.ComponentConfiguration{
-					{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
+					{Component: sveltosv1alpha1.ComponentAddonManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
 				},
 			},
 		}
@@ -48,7 +48,7 @@ var _ = Describe("Logsettings", func() {
 		Expect(f.Value.String()).To(Equal(strconv.Itoa(logsettings.LogDebug)))
 
 		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
-			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
+			{Component: sveltosv1alpha1.ComponentAddonManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -57,7 +57,7 @@ var _ = Describe("Logsettings", func() {
 		Expect(f.Value.String()).To(Equal(strconv.Itoa(logsettings.LogInfo)))
 
 		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
-			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelVerbose},
+			{Component: sveltosv1alpha1.ComponentAddonManager, LogLevel: sveltosv1alpha1.LogLevelVerbose},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -68,7 +68,7 @@ var _ = Describe("Logsettings", func() {
 		newDebugValue := 8
 		instance.SetDebugValue(newDebugValue)
 		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
-			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
+			{Component: sveltosv1alpha1.ComponentAddonManager, LogLevel: sveltosv1alpha1.LogLevelDebug},
 		}
 
 		logsettings.UpdateLogLevel(conf)
@@ -79,7 +79,7 @@ var _ = Describe("Logsettings", func() {
 		newInfoValue := 5
 		instance.SetInfoValue(newInfoValue)
 		conf.Spec.Configuration = []sveltosv1alpha1.ComponentConfiguration{
-			{Component: sveltosv1alpha1.ComponentSveltosManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
+			{Component: sveltosv1alpha1.ComponentAddonManager, LogLevel: sveltosv1alpha1.LogLevelInfo},
 		}
 
 		logsettings.UpdateLogLevel(conf)


### PR DESCRIPTION
For log settings, DebuggingConfiguration CRD, the component name for addon-manager is AddonManager