### PR TITLE
Cluster annotation for addon constraint

### DIFF
--- a/api/v1alpha1/addonconstraint_type.go
+++ b/api/v1alpha1/addonconstraint_type.go
@@ -37,6 +37,12 @@ func GetClusterLabel(clusterNamespace, clusterName string, clusterType *ClusterT
 		strings.ToLower(string(*clusterType)), clusterNamespace, clusterName)
 }
 
+// GetClusterAnnotation returns the annotation added on each cluster that indicates
+// addon constraints for this cluster, if any, are ready
+func GetClusterAnnotation() string {
+	return "addon-constraints-ready"
+}
+
 type OpenAPIValidationRef struct {
 	// Namespace of the referenced resource.
 	// +kubebuilder:validation:MinLength=1


### PR DESCRIPTION
Cluster addons are deployed by addon controller.
Cluster addon constraints are loaded by addon-constraint controller. When new cluster is created it might match both a ClusterProfile and an AddonConstrain.
Matching a ClusterProfile means addons need to be deployed (by addon controller).
Matching an AddonConstraint means some validations are defined and any addon deployed in this cluster should satisfy those validations.

We need a sistem that allows addon constraints to be loaded before any addon is deployed.
Addon-constraint controller will add this annotation to any cluster it is aware of (if addon-constrain controller is aware of a cluster we can assume validations for such cluster are loaded).

Addon controller won't deploy any addons till this annotation is set on a cluster.