### PR TITLE
Fix cluster ready check

### DIFF
--- a/api/v1alpha1/rolerequest_type.go
+++ b/api/v1alpha1/rolerequest_type.go
@@ -28,7 +28,7 @@ const (
 
 	// RoleRequestLabel is added to each object generated for a RoleRequest
 	// in both management and managed clusters
-	RoleRequestLabel = "projectsveltos.io/role-request-name"
+	RoleRequestLabel = "projectsveltos.io/role-request"
 
 	FeatureRoleRequest = "RoleRequest"
 )

--- a/lib/clusterproxy/clusterproxy.go
+++ b/lib/clusterproxy/clusterproxy.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
@@ -207,29 +206,20 @@ func isSveltosClusterReadyToBeConfigured(
 	return sveltosCluster.Status.Ready, nil
 }
 
-// isCAPIClusterReadyToBeConfigured gets all Machines for a given CAPI Cluster and returns true
-// if at least one control plane machine is in running phase
+// isCAPIClusterReadyToBeConfigured checks whether Cluster Status.ControlPlaneReady is set to true
 func isCAPIClusterReadyToBeConfigured(
 	ctx context.Context, c client.Client,
 	cluster *corev1.ObjectReference, logger logr.Logger,
 ) (bool, error) {
 
-	machineList, err := GetMachinesForCluster(ctx, c, cluster, logger)
+	capiCluster := &clusterv1.Cluster{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, capiCluster)
 	if err != nil {
+		logger.Info(fmt.Sprintf("Failed to get Cluster %v", err))
 		return false, err
 	}
 
-	for i := range machineList.Items {
-		if util.IsControlPlaneMachine(&machineList.Items[i]) {
-			if machineList.Items[i].Status.GetTypedPhase() == clusterv1.MachinePhaseRunning ||
-				machineList.Items[i].Status.GetTypedPhase() == clusterv1.MachinePhaseProvisioned {
-
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
+	return capiCluster.Status.ControlPlaneReady, nil
 }
 
 // GetMachinesForCluster find all Machines for a given CAPI Cluster.

--- a/lib/roles/roles.go
+++ b/lib/roles/roles.go
@@ -155,12 +155,6 @@ func ListSecretForOwnner(ctx context.Context, c client.Client, owner client.Obje
 
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
-		if secret.Labels == nil {
-			continue
-		}
-		if _, ok := secret.Labels[sveltosv1alpha1.RoleRequestLabel]; !ok {
-			continue
-		}
 		if deployer.IsOwnerReference(secret, owner) {
 			results = append(results, *secret)
 		}


### PR DESCRIPTION
A ClusterAPI powered cluster is ready when Status.ControlPlaneReady field is set to true.

Check before this PR was incorrect, looking for control plane machines which do not necessarily need to be present.

Fixes #193 