### PR TITLE
List all clusters

### DIFF
--- a/lib/clusterproxy/cluster_utils_test.go
+++ b/lib/clusterproxy/cluster_utils_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/internal/test/helpers/external"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 )
 
@@ -158,7 +159,10 @@ var _ = Describe("Cluster utils", func() {
 			},
 		}
 
+		clusterCRD := external.TestClusterCRD.DeepCopy()
+
 		initObjects := []client.Object{
+			clusterCRD,
 			cluster1,
 			cluster2,
 		}

--- a/lib/clusterproxy/clusterproxy_test.go
+++ b/lib/clusterproxy/clusterproxy_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,6 +53,9 @@ func setupScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	if err := libsveltosv1alpha1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	if err := apiextensionsv1.AddToScheme(s); err != nil {
 		return nil, err
 	}
 	return s, nil


### PR DESCRIPTION
When listing all clusters, add a check to verify if clusterapi is deployed in the management cluster.
Prior this commit, if clusterAPI was not present in the management cluster, list all clusters used to fail with

```
failed to get API group resources: unable to retrieve the complete list of server
APIs: cluster.x-k8s.io/v1beta1:"
```