### PR TITLE
Introducing sharding for sveltos controller

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
     - 'main'
     - 'dev'
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, synchronize, reopened]
 
 
 jobs:
@@ -14,13 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.20.0
     - name: Build
       run: make build
     - name: FMT
@@ -35,13 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.20.0
     - name: ut
       run: make test
       env:

--- a/lib/sharding/sharding_suite_test.go
+++ b/lib/sharding/sharding_suite_test.go
@@ -1,0 +1,47 @@
+package sharding_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	scheme *runtime.Scheme
+)
+
+func TestSharding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sharding Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+
+	ctrl.SetLogger(klog.Background())
+
+	var err error
+	scheme, err = setupScheme()
+	Expect(err).To(BeNil())
+})
+
+func setupScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func randomString() string {
+	const length = 10
+	return util.RandomString(length)
+}

--- a/lib/sharding/utils.go
+++ b/lib/sharding/utils.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharding
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+)
+
+// Sharding can be used to to horizontal scale sveltos.
+// When sharding is used, there will be:
+// - One deployment with shard-key argument not set.
+// - Zero or more deployments with shard-key argument set.
+// A cluster with shardAnnotation will only be managed by
+// the corresponding deployment with matching shard-key.
+// A cluster with no shardAnnotation will only be managed by
+// the deployment started with no shard-key arg.
+
+const (
+	ShardAnnotation = "sharding.projectsveltos.io/key"
+)
+
+// IsShardAMatch returns true if a cluster is a shard match.
+func IsShardAMatch(shardKey string, cluster client.Object) bool {
+	annotations := cluster.GetAnnotations()
+	if len(annotations) == 0 {
+		// A cluster with no ShardAnnotation is only managed by
+		// deployment started with no shard-key arg.
+		return shardKey == ""
+	}
+
+	v, ok := annotations[ShardAnnotation]
+	if !ok {
+		// A cluster with no ShardAnnotation is only managed by
+		// deployment started with no shard-key arg.
+		return shardKey == ""
+	}
+
+	return v == shardKey
+}
+
+// When sharding is used, each cluster at any point of time
+// it has none or a shard key.
+// It is sometimes necessary to keep track of cluster shard
+// being modified. For instance, with respect to add-on and application
+// deployment, each addon-controller keeps in memory information
+// of which clusterSummary instance is managing an helm chart in a given
+// cluster.
+// If cluster shard is changed, the new addon-controller will have to detect
+// it and rebuild the in-memory information.
+// A ConfigMap is used for that. Following methods need to be used by
+// any sveltos controller that wants to track this information
+
+// RegisterClusterShard register a cluster,shard pair.
+// feature is a string representing the entity requesting the tracking.
+// component indicates the sveltos component requesting it.
+// returns a bool indicating whether the cluster:shard pair has changed and an error
+// if any occurred
+func RegisterClusterShard(ctx context.Context, c client.Client, component sveltosv1alpha1.Component,
+	feature, shard, clusterNamespace, clusterName string, clusterType sveltosv1alpha1.ClusterType) (bool, error) {
+
+	cm, err := getConfigMap(ctx, c, component, feature)
+	if err != nil {
+		return false, err
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	clusterId := fmt.Sprintf("%s-%s-%s", clusterType, clusterNamespace, clusterName)
+	currentShard, ok := cm.Data[clusterId]
+	if !ok {
+		// First time we track cluster:shard pair
+
+		cm.Data[clusterId] = shard
+		return false, updateConfigMap(ctx, c, cm)
+	}
+
+	if currentShard != shard {
+		// Cluster shard has changed
+		cm.Data[clusterId] = shard
+		return true, updateConfigMap(ctx, c, cm)
+	}
+
+	// Cluster shard has not changed
+	return false, nil
+}
+
+const (
+	configMapName      = "clustersharding"
+	configMapNamespace = "projectsveltos"
+)
+
+func getConfigMapName(component sveltosv1alpha1.Component, feature string) string {
+	return fmt.Sprintf("%s-%s-%s", configMapName,
+		strings.ToLower(string(component)),
+		strings.ToLower(feature))
+}
+
+func getConfigMap(ctx context.Context, c client.Client, component sveltosv1alpha1.Component,
+	feature string) (*corev1.ConfigMap, error) {
+
+	cm := &corev1.ConfigMap{}
+	name := getConfigMapName(component, feature)
+
+	err := c.Get(ctx, types.NamespacedName{Namespace: configMapNamespace, Name: name}, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return createConfigMap(ctx, c, component, feature)
+		}
+	}
+
+	return cm, nil
+}
+
+func createConfigMap(ctx context.Context, c client.Client, component sveltosv1alpha1.Component,
+	feature string) (*corev1.ConfigMap, error) {
+
+	name := getConfigMapName(component, feature)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: configMapNamespace,
+			Name:      name,
+		},
+	}
+
+	err := c.Create(ctx, cm)
+	return cm, err
+}
+
+func updateConfigMap(ctx context.Context, c client.Client, cm *corev1.ConfigMap) error {
+	return c.Update(ctx, cm)
+}

--- a/lib/sharding/utils_test.go
+++ b/lib/sharding/utils_test.go
@@ -1,0 +1,103 @@
+package sharding_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/sharding"
+)
+
+var _ = Describe("Sharding", func() {
+	It("RegisterClusterShard returns correct information with respect to cluster sharding", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		cluster := &corev1.ObjectReference{
+			Name:       randomString(),
+			Namespace:  randomString(),
+			Kind:       libsveltosv1alpha1.SveltosClusterKind,
+			APIVersion: libsveltosv1alpha1.GroupVersion.String(),
+		}
+
+		shard := randomString()
+		// First time, add entry and return false since cluster:shard was never changed
+		shardChanged, err := sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", shard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeFalse())
+
+		// return false since cluster:shard was never changed
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", shard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeFalse())
+
+		// return true since cluster:shard has changed
+		newShard := randomString()
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeTrue())
+
+		// return false since cluster:shard has not changed (and previous step updated configMap)
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeFalse())
+
+		// register capi cluster with same namespace/name of sveltoscluster used so far
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeFalse())
+
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeFalse())
+
+		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1alpha1.ComponentAddonManager,
+			"helm", randomString(), cluster.Namespace, cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
+		Expect(err).To(BeNil())
+		Expect(shardChanged).To(BeTrue())
+	})
+
+	It("IsShardAMatch returns false when shard is not a match", func() {
+		cluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   randomString(),
+				Name:        randomString(),
+				Annotations: map[string]string{},
+			},
+		}
+
+		shard := randomString()
+
+		Expect(sharding.IsShardAMatch(shard, cluster)).To(BeFalse())
+
+		cluster.Annotations[sharding.ShardAnnotation] = randomString()
+		Expect(sharding.IsShardAMatch(shard, cluster)).To(BeFalse())
+	})
+
+	It("IsShardAMatch returns true when shard is a match", func() {
+		shard := randomString()
+
+		cluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+				Annotations: map[string]string{
+					sharding.ShardAnnotation: shard,
+				},
+			},
+		}
+
+		Expect(sharding.IsShardAMatch(shard, cluster)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
This PR introduces:
1. the annotation to add to clusters to shard them
2. utility functions needed by controllers to get clusters filtering by shard and detecting whether a cluster belongs to a given shard

In general, a cluster with the annotation

```
sharding.projectsveltos.io/key: <shard-value>
```

will only be managed by the controller started explicitly for that shard.

A cluster with no annotation will be managed by the default controller.