### PR TITLE
Add ComponentShardController

### DIFF
--- a/api/v1alpha1/debuggingconfiguration_types.go
+++ b/api/v1alpha1/debuggingconfiguration_types.go
@@ -73,6 +73,9 @@ const (
 
 	// ComponentEventManager is the event-manager pod
 	ComponentEventManager = Component("EventManager")
+
+	// ComponentShardController is the shard-controller pod
+	ComponentShardController = Component("ShardController")
 )
 
 // ComponentConfiguration is the debugging configuration to be applied to a Sveltos component.


### PR DESCRIPTION
New controller, shard-controller, is being introduced in Sveltos. This controller will be responsible for managing cluster shards.

As for any other sveltos component, the log severity can be programmatically configured. So add option to support that.