### PR TITLE
Matching clusters: only cluster ready to be programmed can be a match

### DIFF
--- a/lib/clusterproxy/cluster_utils.go
+++ b/lib/clusterproxy/cluster_utils.go
@@ -424,6 +424,11 @@ func getMatchingCAPIClusters(ctx context.Context, c client.Client, selector labe
 			continue
 		}
 
+		if !isCAPIControlPlaneReady(cluster) {
+			// Only ready cluster can match
+			continue
+		}
+
 		addTypeInformationToObject(c.Scheme(), cluster)
 		if selector.Matches(labels.Set(cluster.Labels)) {
 			matching = append(matching, corev1.ObjectReference{
@@ -464,6 +469,11 @@ func getMatchingSveltosClusters(ctx context.Context, c client.Client, selector l
 
 		if !cluster.DeletionTimestamp.IsZero() {
 			// Only existing cluster can match
+			continue
+		}
+
+		if !isSveltosClusterStatusReady(cluster) {
+			// Only ready cluster can match
 			continue
 		}
 

--- a/lib/clusterproxy/cluster_utils_test.go
+++ b/lib/clusterproxy/cluster_utils_test.go
@@ -52,6 +52,9 @@ var _ = Describe("Cluster utils", func() {
 			Spec: clusterv1.ClusterSpec{
 				Paused: true,
 			},
+			Status: clusterv1.ClusterStatus{
+				ControlPlaneReady: true,
+			},
 		}
 
 		sveltosCluster = &libsveltosv1alpha1.SveltosCluster{
@@ -61,6 +64,9 @@ var _ = Describe("Cluster utils", func() {
 			},
 			Spec: libsveltosv1alpha1.SveltosClusterSpec{
 				Paused: true,
+			},
+			Status: libsveltosv1alpha1.SveltosClusterStatus{
+				Ready: true,
 			},
 		}
 	})
@@ -270,12 +276,18 @@ var _ = Describe("Cluster utils", func() {
 				Namespace: randomString(),
 				Labels:    currentLabels,
 			},
+			Status: libsveltosv1alpha1.SveltosClusterStatus{
+				Ready: true,
+			},
 		}
 
 		nonMatchingSveltosCluster := &libsveltosv1alpha1.SveltosCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
+			},
+			Status: libsveltosv1alpha1.SveltosClusterStatus{
+				Ready: true,
 			},
 		}
 
@@ -287,7 +299,7 @@ var _ = Describe("Cluster utils", func() {
 			nonMatchingSveltosCluster,
 		}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
 		parsedSelector, _ := labels.Parse(string(selector))
 

--- a/lib/clusterproxy/clusterproxy.go
+++ b/lib/clusterproxy/clusterproxy.go
@@ -210,7 +210,11 @@ func isSveltosClusterReadyToBeConfigured(
 		return false, err
 	}
 
-	return sveltosCluster.Status.Ready, nil
+	return isSveltosClusterStatusReady(sveltosCluster), nil
+}
+
+func isSveltosClusterStatusReady(sveltosCluster *libsveltosv1alpha1.SveltosCluster) bool {
+	return sveltosCluster.Status.Ready
 }
 
 // isCAPIClusterReadyToBeConfigured checks whether Cluster:
@@ -228,16 +232,20 @@ func isCAPIClusterReadyToBeConfigured(
 		return false, err
 	}
 
+	return isCAPIControlPlaneReady(capiCluster), nil
+}
+
+func isCAPIControlPlaneReady(capiCluster *clusterv1.Cluster) bool {
 	for i := range capiCluster.Status.Conditions {
 		c := capiCluster.Status.Conditions[i]
 		if c.Type == clusterv1.ControlPlaneInitializedCondition &&
 			c.Status == corev1.ConditionTrue {
 
-			return true, nil
+			return true
 		}
 	}
 
-	return capiCluster.Status.ControlPlaneReady, nil
+	return capiCluster.Status.ControlPlaneReady
 }
 
 // GetMachinesForCluster find all Machines for a given CAPI Cluster.


### PR DESCRIPTION
This is a behavior change. Previoulsy, only deleted clusters were not considered.