### PR TITLE
(feat) Add ability to ignore resource for configuration drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 
 GOLANGCI_LINT_VERSION := "v1.57.2"
 
-KUSTOMIZE_VER := v4.5.2
+KUSTOMIZE_VER := v5.3.0
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
-KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4
+KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v5
 $(KUSTOMIZE): # Build kustomize from tools folder.
 	CGO_ENABLED=0 GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(KUSTOMIZE_PKG) $(KUSTOMIZE_BIN) $(KUSTOMIZE_VER)
 

--- a/api/v1alpha1/resourcesummary_type.go
+++ b/api/v1alpha1/resourcesummary_type.go
@@ -55,6 +55,11 @@ type Resource struct {
 
 	// Version of the resource deployed in the Cluster.
 	Version string `json:"version"`
+
+	// IgnoreForConfigurationDrift indicates to not track resource
+	// for configuration drift detection.
+	// +kubebuilder:default:=false
+	IgnoreForConfigurationDrift bool `json:"ignoreForConfigurationDrift"`
 }
 
 type HelmResources struct {

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2279,6 +2279,7 @@ func autoConvert_v1alpha1_Resource_To_v1beta1_Resource(in *Resource, out *v1beta
 	out.Group = in.Group
 	out.Kind = in.Kind
 	out.Version = in.Version
+	out.IgnoreForConfigurationDrift = in.IgnoreForConfigurationDrift
 	return nil
 }
 
@@ -2293,6 +2294,7 @@ func autoConvert_v1beta1_Resource_To_v1alpha1_Resource(in *v1beta1.Resource, out
 	out.Group = in.Group
 	out.Kind = in.Kind
 	out.Version = in.Version
+	out.IgnoreForConfigurationDrift = in.IgnoreForConfigurationDrift
 	return nil
 }
 

--- a/api/v1beta1/resourcesummary_type.go
+++ b/api/v1beta1/resourcesummary_type.go
@@ -55,6 +55,11 @@ type Resource struct {
 
 	// Version of the resource deployed in the Cluster.
 	Version string `json:"version"`
+
+	// IgnoreForConfigurationDrift indicates to not track resource
+	// for configuration drift detection.
+	// +kubebuilder:default:=false
+	IgnoreForConfigurationDrift bool `json:"ignoreForConfigurationDrift"`
 }
 
 type HelmResources struct {

--- a/config/crd/bases/lib.projectsveltos.io_resourcesummaries.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_resourcesummaries.yaml
@@ -56,6 +56,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -74,6 +80,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -103,6 +110,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -121,6 +134,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -134,6 +148,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -152,6 +172,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -171,6 +192,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -189,6 +216,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -208,6 +236,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -226,6 +260,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -244,6 +279,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -262,6 +303,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -318,6 +360,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -336,6 +384,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -365,6 +414,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -383,6 +438,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -396,6 +452,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -414,6 +476,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -433,6 +496,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -451,6 +520,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -470,6 +540,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -488,6 +564,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -506,6 +583,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -524,6 +607,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/gofuzz v1.2.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
@@ -38,7 +39,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/lib/crd/resourcesummaries.go
+++ b/lib/crd/resourcesummaries.go
@@ -74,6 +74,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -92,6 +98,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -121,6 +128,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -139,6 +152,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -152,6 +166,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -170,6 +190,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -189,6 +210,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -207,6 +234,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -226,6 +254,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -244,6 +278,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -262,6 +297,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -280,6 +321,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -336,6 +378,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -354,6 +402,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -383,6 +432,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -401,6 +456,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -414,6 +470,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -432,6 +494,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -451,6 +514,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -469,6 +538,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -488,6 +558,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -506,6 +582,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -524,6 +601,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -542,6 +625,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_resourcesummaries.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_resourcesummaries.lib.projectsveltos.io.yaml
@@ -55,6 +55,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -73,6 +79,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -102,6 +109,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -120,6 +133,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -133,6 +147,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -151,6 +171,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -170,6 +191,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -188,6 +215,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -207,6 +235,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -225,6 +259,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -243,6 +278,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -261,6 +302,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -317,6 +359,12 @@ spec:
                           group:
                             description: Group of the resource deployed in the Cluster.
                             type: string
+                          ignoreForConfigurationDrift:
+                            default: false
+                            description: |-
+                              IgnoreForConfigurationDrift indicates to not track resource
+                              for configuration drift detection.
+                            type: boolean
                           kind:
                             description: Kind of the resource deployed in the Cluster.
                             minLength: 1
@@ -335,6 +383,7 @@ spec:
                             type: string
                         required:
                         - group
+                        - ignoreForConfigurationDrift
                         - kind
                         - name
                         - version
@@ -364,6 +413,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -382,6 +437,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -395,6 +451,12 @@ spec:
                     group:
                       description: Group of the resource deployed in the Cluster.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -413,6 +475,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -432,6 +495,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -450,6 +519,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -469,6 +539,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -487,6 +563,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version
@@ -505,6 +582,12 @@ spec:
                     hash:
                       description: Hash is the hash of a resource's data.
                       type: string
+                    ignoreForConfigurationDrift:
+                      default: false
+                      description: |-
+                        IgnoreForConfigurationDrift indicates to not track resource
+                        for configuration drift detection.
+                      type: boolean
                     kind:
                       description: Kind of the resource deployed in the Cluster.
                       minLength: 1
@@ -523,6 +606,7 @@ spec:
                       type: string
                   required:
                   - group
+                  - ignoreForConfigurationDrift
                   - kind
                   - name
                   - version


### PR DESCRIPTION
Add field

```yaml
        // IgnoreForConfigurationDrift indicates to not track resource
        // for configuration drift detection.
        IgnoreForConfigurationDrift bool `json:"ignoreForConfigurationDrift"`
```

to Resource. Drift detection manager won't track any resource with such field set for configuration drift

[Story](https://github.com/projectsveltos/addon-controller/issues/612)