### PR TITLE
(bug) pre deployment patching

### DIFF
--- a/lib/patcher/patcher.go
+++ b/lib/patcher/patcher.go
@@ -54,6 +54,7 @@ func (k *CustomPatchPostRenderer) RunUnstructured(unstructuredObjs []*unstructur
 			return nil, err
 		}
 		renderedManifests.Write(data)
+		renderedManifests.Write([]byte("---\n"))
 	}
 
 	manifests, err := k.Run(&renderedManifests)


### PR DESCRIPTION
When multiple resources had to be patched there was an issue. This PR fixes it.

```bash
wget https://github.com/fluxcd/flux2/releases/download/v2.3.0/install.yaml
kubectl create configmap install-flux --from-file=install.yaml
```

Then create a ClusterProfile referencing above ConfigMap with patches

```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: fluxcd
spec:
  clusterSelector:
    matchLabels:
      env: fv
  syncMode: ContinuousWithDriftDetection
  policyRefs:
  - name: install-flux
    namespace: default
    kind: ConfigMap
  patches:
  - target:
      kind: Namespace
      name: ".*"
    patch: |
      - op: add
        path: /metadata/labels/type
        value: operator
```

all resources are deployed. Snipped from ClusterSummary:

```yaml
  status:
    dependencies: no dependencies
    deployedGVKs:
    - deployedGroupVersionKind:
      - Namespace.v1.
      - ResourceQuota.v1.
      - CustomResourceDefinition.v1.apiextensions.k8s.io
      - ServiceAccount.v1.
      - ClusterRole.v1.rbac.authorization.k8s.io
      - ClusterRoleBinding.v1.rbac.authorization.k8s.io
      - Service.v1.
      - Deployment.v1.apps
      - NetworkPolicy.v1.networking.k8s.io
      featureID: Resources
    featureSummaries:
    - featureID: Resources
      hash: fbu02/VIWPD2uWEi/0reXeS/SAv740mmTTTYz0A66Q8=
      lastAppliedTime: "2024-07-10T12:07:31Z"
      status: Provisioned
```

and the namespace has the `type: operator` label

```yaml
apiVersion: v1
kind: Namespace
metadata:
  creationTimestamp: "2024-07-10T12:07:23Z"
  labels:
    ...
    type: operator
  name: flux-system
```