### PR TITLE
(feat) Set connection status in SveltosCluster

### DIFF
--- a/api/v1alpha1/sveltoscluster_type.go
+++ b/api/v1alpha1/sveltoscluster_type.go
@@ -36,6 +36,10 @@ type ActiveWindow struct {
 	To string `json:"to"`
 }
 
+// ConnectionStatus specifies whether connecting to managed cluster is healthy or not
+// +kubebuilder:validation:Enum:=Healthy;Down
+type ConnectionStatus string
+
 type TokenRequestRenewalOption struct {
 	// RenewTokenRequestInterval is the interval at which to renew the TokenRequest
 	RenewTokenRequestInterval metav1.Duration `json:"renewTokenRequestInterval"`
@@ -66,7 +70,14 @@ type SveltosClusterSpec struct {
 	// ActiveWindow is an optional field for automatically pausing and unpausing
 	// the cluster.
 	// If not specified, the cluster will not be paused or unpaused automatically.
+	// +optional
 	ActiveWindow *ActiveWindow `json:"activeWindow,omitempty"`
+
+	// ConsecutiveFailureThreshold is the maximum number of consecutive connection
+	// failures before setting the problem status in Status.ConnectionStatus
+	// +kubebuilder:default:=3
+	// +optional
+	ConsecutiveFailureThreshold int `json:"consecutiveFailureThreshold,omitempty"`
 }
 
 // SveltosClusterStatus defines the status of SveltosCluster
@@ -78,6 +89,11 @@ type SveltosClusterStatus struct {
 	// Ready is the state of the cluster.
 	// +optional
 	Ready bool `json:"ready,omitempty"`
+
+	// ConnectionStatus indicates whether connection from the management cluster
+	// to the managed cluster is healthy
+	// +optional
+	ConnectionStatus ConnectionStatus `json:"connectionStatus,omitempty"`
 
 	// FailureMessage is a human consumable message explaining the
 	// misconfiguration
@@ -96,6 +112,11 @@ type SveltosClusterStatus struct {
 	// Information when next pause cluster is scheduled
 	// +optional
 	NextPause *metav1.Time `json:"nextPause,omitempty"`
+
+	// connectionFailures is the number of consecutive failed attempts to connect
+	// to the remote cluster.
+	// +optional
+	ConnectionFailures int `json:"connectionFailures,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2888,6 +2888,7 @@ func autoConvert_v1alpha1_SveltosClusterSpec_To_v1beta1_SveltosClusterSpec(in *S
 	out.TokenRequestRenewalOption = (*v1beta1.TokenRequestRenewalOption)(unsafe.Pointer(in.TokenRequestRenewalOption))
 	out.ArbitraryData = *(*map[string]string)(unsafe.Pointer(&in.ArbitraryData))
 	out.ActiveWindow = (*v1beta1.ActiveWindow)(unsafe.Pointer(in.ActiveWindow))
+	out.ConsecutiveFailureThreshold = in.ConsecutiveFailureThreshold
 	return nil
 }
 
@@ -2902,6 +2903,7 @@ func autoConvert_v1beta1_SveltosClusterSpec_To_v1alpha1_SveltosClusterSpec(in *v
 	out.TokenRequestRenewalOption = (*TokenRequestRenewalOption)(unsafe.Pointer(in.TokenRequestRenewalOption))
 	out.ArbitraryData = *(*map[string]string)(unsafe.Pointer(&in.ArbitraryData))
 	out.ActiveWindow = (*ActiveWindow)(unsafe.Pointer(in.ActiveWindow))
+	out.ConsecutiveFailureThreshold = in.ConsecutiveFailureThreshold
 	return nil
 }
 
@@ -2913,10 +2915,12 @@ func Convert_v1beta1_SveltosClusterSpec_To_v1alpha1_SveltosClusterSpec(in *v1bet
 func autoConvert_v1alpha1_SveltosClusterStatus_To_v1beta1_SveltosClusterStatus(in *SveltosClusterStatus, out *v1beta1.SveltosClusterStatus, s conversion.Scope) error {
 	out.Version = in.Version
 	out.Ready = in.Ready
+	out.ConnectionStatus = v1beta1.ConnectionStatus(in.ConnectionStatus)
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.LastReconciledTokenRequestAt = in.LastReconciledTokenRequestAt
 	out.NextUnpause = (*metav1.Time)(unsafe.Pointer(in.NextUnpause))
 	out.NextPause = (*metav1.Time)(unsafe.Pointer(in.NextPause))
+	out.ConnectionFailures = in.ConnectionFailures
 	return nil
 }
 
@@ -2928,10 +2932,12 @@ func Convert_v1alpha1_SveltosClusterStatus_To_v1beta1_SveltosClusterStatus(in *S
 func autoConvert_v1beta1_SveltosClusterStatus_To_v1alpha1_SveltosClusterStatus(in *v1beta1.SveltosClusterStatus, out *SveltosClusterStatus, s conversion.Scope) error {
 	out.Version = in.Version
 	out.Ready = in.Ready
+	out.ConnectionStatus = ConnectionStatus(in.ConnectionStatus)
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.LastReconciledTokenRequestAt = in.LastReconciledTokenRequestAt
 	out.NextUnpause = (*metav1.Time)(unsafe.Pointer(in.NextUnpause))
 	out.NextPause = (*metav1.Time)(unsafe.Pointer(in.NextPause))
+	out.ConnectionFailures = in.ConnectionFailures
 	return nil
 }
 

--- a/api/v1beta1/sveltoscluster_type.go
+++ b/api/v1beta1/sveltoscluster_type.go
@@ -36,6 +36,10 @@ type ActiveWindow struct {
 	To string `json:"to"`
 }
 
+// ConnectionStatus specifies whether connecting to managed cluster is healthy or not
+// +kubebuilder:validation:Enum:=Healthy;Down
+type ConnectionStatus string
+
 type TokenRequestRenewalOption struct {
 	// RenewTokenRequestInterval is the interval at which to renew the TokenRequest
 	RenewTokenRequestInterval metav1.Duration `json:"renewTokenRequestInterval"`
@@ -67,6 +71,12 @@ type SveltosClusterSpec struct {
 	// the cluster.
 	// If not specified, the cluster will not be paused or unpaused automatically.
 	ActiveWindow *ActiveWindow `json:"activeWindow,omitempty"`
+
+	// ConsecutiveFailureThreshold is the maximum number of consecutive connection
+	// failures before setting the problem status in Status.ConnectionStatus
+	// +kubebuilder:default:=3
+	// +optional
+	ConsecutiveFailureThreshold int `json:"consecutiveFailureThreshold,omitempty"`
 }
 
 // SveltosClusterStatus defines the status of SveltosCluster
@@ -78,6 +88,11 @@ type SveltosClusterStatus struct {
 	// Ready is the state of the cluster.
 	// +optional
 	Ready bool `json:"ready,omitempty"`
+
+	// ConnectionStatus indicates whether connection from the management cluster
+	// to the managed cluster is healthy
+	// +optional
+	ConnectionStatus ConnectionStatus `json:"connectionStatus,omitempty"`
 
 	// FailureMessage is a human consumable message explaining the
 	// misconfiguration
@@ -96,6 +111,11 @@ type SveltosClusterStatus struct {
 	// Information when next pause cluster is scheduled
 	// +optional
 	NextPause *metav1.Time `json:"nextPause,omitempty"`
+
+	// connectionFailures is the number of consecutive failed attempts to connect
+	// to the remote cluster.
+	// +optional
+	ConnectionFailures int `json:"connectionFailures,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
@@ -70,6 +70,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -104,6 +110,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the
@@ -190,6 +209,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -224,6 +249,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the

--- a/lib/crd/sveltosclusters.go
+++ b/lib/crd/sveltosclusters.go
@@ -88,6 +88,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -122,6 +128,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the
@@ -208,6 +227,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -242,6 +267,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
@@ -69,6 +69,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -103,6 +109,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the
@@ -189,6 +208,12 @@ spec:
                 - from
                 - to
                 type: object
+              consecutiveFailureThreshold:
+                default: 3
+                description: |-
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
               data:
                 additionalProperties:
                   type: string
@@ -223,6 +248,19 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              connectionFailures:
+                description: |-
+                  connectionFailures is the number of consecutive failed attempts to connect
+                  to the remote cluster.
+                type: integer
+              connectionStatus:
+                description: |-
+                  ConnectionStatus indicates whether connection from the management cluster
+                  to the managed cluster is healthy
+                enum:
+                - Healthy
+                - Down
+                type: string
               failureMessage:
                 description: |-
                   FailureMessage is a human consumable message explaining the


### PR DESCRIPTION
Sveltos periodically attempts to connect to managed SveltosClusters. Upon successful initial connection, the `Ready` status is set to true and remains unchanged.

To indicate connection health, this PR introduces a `ConnectionStatus` field within the Status. This field can be either `Healthy` or `Down`. The status transitions to `Down` after a configurable number of consecutive connection failures, which defaults to three.