### PR TITLE
(feat) Add name to ResourceSelector

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -156,6 +156,10 @@ type ResourceSelector struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
+	// Name of the resource deployed in the  Cluster.
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// Evaluate contains a function "evaluate" in lua language.
 	// The function will be passed one of the object selected based on
 	// above criteria.

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2442,6 +2442,7 @@ func autoConvert_v1alpha1_ResourceSelector_To_v1beta1_ResourceSelector(in *Resou
 	out.Kind = in.Kind
 	out.LabelFilters = *(*[]v1beta1.LabelFilter)(unsafe.Pointer(&in.LabelFilters))
 	out.Namespace = in.Namespace
+	out.Name = in.Name
 	out.Evaluate = in.Evaluate
 	return nil
 }
@@ -2457,6 +2458,7 @@ func autoConvert_v1beta1_ResourceSelector_To_v1alpha1_ResourceSelector(in *v1bet
 	out.Kind = in.Kind
 	out.LabelFilters = *(*[]LabelFilter)(unsafe.Pointer(&in.LabelFilters))
 	out.Namespace = in.Namespace
+	out.Name = in.Name
 	out.Evaluate = in.Evaluate
 	return nil
 }

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -165,6 +165,10 @@ type ResourceSelector struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
+	// Name of the resource deployed in the  Cluster.
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// Evaluate contains a function "evaluate" in lua language.
 	// The function will be passed one of the object selected based on
 	// above criteria.

--- a/config/crd/bases/lib.projectsveltos.io_classifiers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_classifiers.yaml
@@ -123,6 +123,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.
@@ -440,6 +443,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.

--- a/config/crd/bases/lib.projectsveltos.io_eventsources.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventsources.yaml
@@ -104,6 +104,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -214,6 +217,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.

--- a/config/crd/bases/lib.projectsveltos.io_healthchecks.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_healthchecks.yaml
@@ -101,6 +101,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -209,6 +212,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.

--- a/lib/crd/classifiers.go
+++ b/lib/crd/classifiers.go
@@ -141,6 +141,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.
@@ -458,6 +461,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.

--- a/lib/crd/eventsources.go
+++ b/lib/crd/eventsources.go
@@ -122,6 +122,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -232,6 +235,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.

--- a/lib/crd/healthchecks.go
+++ b/lib/crd/healthchecks.go
@@ -119,6 +119,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -227,6 +230,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
@@ -122,6 +122,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.
@@ -439,6 +442,9 @@ spec:
                             - value
                             type: object
                           type: array
+                        name:
+                          description: Name of the resource deployed in the  Cluster.
+                          type: string
                         namespace:
                           description: |-
                             Namespace of the resource deployed in the  Cluster.

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventsources.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventsources.lib.projectsveltos.io.yaml
@@ -103,6 +103,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -213,6 +216,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_healthchecks.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_healthchecks.lib.projectsveltos.io.yaml
@@ -100,6 +100,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.
@@ -208,6 +211,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    name:
+                      description: Name of the resource deployed in the  Cluster.
+                      type: string
                     namespace:
                       description: |-
                         Namespace of the resource deployed in the  Cluster.


### PR DESCRIPTION
In several situation, an event is identified by the creation of a specific resource.
Add `name` to ResourceSelector to better handle this scenarion.

Before this PR, to watch for a specific resource, we had to write Lua code in the `evaluate` field.
With this PR, that is not needed anymore.