### PR TITLE
Token renewal: specify ServiceAccount

### DIFF
--- a/api/v1alpha1/sveltoscluster_type.go
+++ b/api/v1alpha1/sveltoscluster_type.go
@@ -51,6 +51,18 @@ const (
 type TokenRequestRenewalOption struct {
 	// RenewTokenRequestInterval is the interval at which to renew the TokenRequest
 	RenewTokenRequestInterval metav1.Duration `json:"renewTokenRequestInterval"`
+
+	// SANamespace is the namespace of the ServiceAccount to renew the token for.
+	// If specified, ServiceAccount must exist in the managed cluster.
+	// If not specified, sveltos will try to deduce it from current kubeconfig
+	// +optional
+	SANamespace string `json:"saNamespace,omitempty"`
+
+	// SAName is name of the ServiceAccount to renew the token for.
+	// If specified, ServiceAccount must exist in the managed cluster.
+	// If not specified, sveltos will try to deduce it from current kubeconfig
+	// +optional
+	SAName string `json:"saName,omitempty"`
 }
 
 // SveltosClusterSpec defines the desired state of SveltosCluster

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2951,6 +2951,8 @@ func Convert_v1beta1_SveltosClusterStatus_To_v1alpha1_SveltosClusterStatus(in *v
 
 func autoConvert_v1alpha1_TokenRequestRenewalOption_To_v1beta1_TokenRequestRenewalOption(in *TokenRequestRenewalOption, out *v1beta1.TokenRequestRenewalOption, s conversion.Scope) error {
 	out.RenewTokenRequestInterval = in.RenewTokenRequestInterval
+	out.SANamespace = in.SANamespace
+	out.SAName = in.SAName
 	return nil
 }
 
@@ -2961,6 +2963,8 @@ func Convert_v1alpha1_TokenRequestRenewalOption_To_v1beta1_TokenRequestRenewalOp
 
 func autoConvert_v1beta1_TokenRequestRenewalOption_To_v1alpha1_TokenRequestRenewalOption(in *v1beta1.TokenRequestRenewalOption, out *TokenRequestRenewalOption, s conversion.Scope) error {
 	out.RenewTokenRequestInterval = in.RenewTokenRequestInterval
+	out.SANamespace = in.SANamespace
+	out.SAName = in.SAName
 	return nil
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v1beta1/sveltoscluster_type.go
+++ b/api/v1beta1/sveltoscluster_type.go
@@ -51,6 +51,18 @@ const (
 type TokenRequestRenewalOption struct {
 	// RenewTokenRequestInterval is the interval at which to renew the TokenRequest
 	RenewTokenRequestInterval metav1.Duration `json:"renewTokenRequestInterval"`
+
+	// SANamespace is the namespace of the ServiceAccount to renew the token for.
+	// If specified, ServiceAccount must exist in the managed cluster.
+	// If not specified, sveltos will try to deduce it from current kubeconfig
+	// +optional
+	SANamespace string `json:"saNamespace,omitempty"`
+
+	// SAName is name of the ServiceAccount to renew the token for.
+	// If specified, ServiceAccount must exist in the managed cluster.
+	// If not specified, sveltos will try to deduce it from current kubeconfig
+	// +optional
+	SAName string `json:"saName,omitempty"`
 }
 
 // SveltosClusterSpec defines the desired state of SveltosCluster

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
@@ -102,6 +102,18 @@ spec:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
                     type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
                 required:
                 - renewTokenRequestInterval
                 type: object
@@ -239,6 +251,18 @@ spec:
                   renewTokenRequestInterval:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
+                    type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
                     type: string
                 required:
                 - renewTokenRequestInterval

--- a/lib/crd/sveltosclusters.go
+++ b/lib/crd/sveltosclusters.go
@@ -120,6 +120,18 @@ spec:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
                     type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
                 required:
                 - renewTokenRequestInterval
                 type: object
@@ -257,6 +269,18 @@ spec:
                   renewTokenRequestInterval:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
+                    type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
                     type: string
                 required:
                 - renewTokenRequestInterval

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
@@ -101,6 +101,18 @@ spec:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
                     type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
                 required:
                 - renewTokenRequestInterval
                 type: object
@@ -238,6 +250,18 @@ spec:
                   renewTokenRequestInterval:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest
+                    type: string
+                  saName:
+                    description: |-
+                      SAName is name of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
+                    type: string
+                  saNamespace:
+                    description: |-
+                      SANamespace is the namespace of the ServiceAccount to renew the token for.
+                      If specified, ServiceAccount must exist in the managed cluster.
+                      If not specified, sveltos will try to deduce it from current kubeconfig
                     type: string
                 required:
                 - renewTokenRequestInterval


### PR DESCRIPTION
When renewing the token, Sveltos can be passed the namespace/name of the ServiceAccount to renew the token for.