### PR TITLE
(feat) Enhance ResourceInfo to contain current deployed resource

### DIFF
--- a/lib/crd/watcher_test.go
+++ b/lib/crd/watcher_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/klog/v2/textlogger"
 
 	"github.com/projectsveltos/libsveltos/lib/crd"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 var (
@@ -91,7 +91,7 @@ var _ = Describe("WatchCustomResourceDefinition", func() {
 		defer cancel()
 		go crd.WatchCustomResourceDefinition(watcherCtx, testEnv.Config, handler, logger)
 
-		crd, err := utils.GetUnstructured([]byte(crdYAML))
+		crd, err := k8s_utils.GetUnstructured([]byte(crdYAML))
 		Expect(err).To(BeNil())
 
 		Expect(testEnv.Create(watcherCtx, crd)).To(Succeed())

--- a/lib/k8s_utils/utils_suite_test.go
+++ b/lib/k8s_utils/utils_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils_test
+package k8s_utils_test
 
 import (
 	"context"

--- a/lib/k8s_utils/utils_test.go
+++ b/lib/k8s_utils/utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils_test
+package k8s_utils_test
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2/textlogger"
 
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 const (
@@ -51,16 +51,16 @@ rules:
 
 var _ = Describe("utils ", func() {
 	It("GetUnstructured returns proper object", func() {
-		policy, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
+		policy, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
 		Expect(err).To(BeNil())
 		Expect(policy.GetKind()).To(Equal("ClusterRole"))
 	})
 
 	It("GetDynamicResourceInterface returns dynamic resource interface", func() {
-		policy, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
+		policy, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
 		Expect(err).To(BeNil())
 
-		dr, err := utils.GetDynamicResourceInterface(testEnv.Config, policy.GroupVersionKind(), policy.GetNamespace())
+		dr, err := k8s_utils.GetDynamicResourceInterface(testEnv.Config, policy.GroupVersionKind(), policy.GetNamespace())
 		Expect(err).To(BeNil())
 
 		_, err = dr.Create(ctx, policy, metav1.CreateOptions{})
@@ -76,11 +76,11 @@ var _ = Describe("utils ", func() {
 	})
 
 	It("should validate UserID and IDToken input in GetKubeconfigWithUserToken()", func() {
-		_, err := utils.GetKubeconfigWithUserToken(ctx, nil, []byte(caData), "user@example.org", serverValue)
+		_, err := k8s_utils.GetKubeconfigWithUserToken(ctx, nil, []byte(caData), "user@example.org", serverValue)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("userID and IDToken cannot be empty"))
 
-		_, err = utils.GetKubeconfigWithUserToken(ctx, []byte("0x123456"), []byte(caData), "", serverValue)
+		_, err = k8s_utils.GetKubeconfigWithUserToken(ctx, []byte("0x123456"), []byte(caData), "", serverValue)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("userID and IDToken cannot be empty"))
 	})
@@ -89,7 +89,7 @@ var _ = Describe("utils ", func() {
 		server := serverValue
 
 		By("Calling GetKubeconfigWithUserToken()")
-		kubeconfig, err := utils.GetKubeconfigWithUserToken(ctx, []byte("0x123456"), []byte(caData), "user@example.org", server)
+		kubeconfig, err := k8s_utils.GetKubeconfigWithUserToken(ctx, []byte("0x123456"), []byte(caData), "user@example.org", server)
 		Expect(err).To(Succeed())
 		Expect(kubeconfig).ToNot(BeNil())
 
@@ -106,7 +106,7 @@ var _ = Describe("utils ", func() {
 	})
 
 	It("GetKubernetesVersion returns cluster Kubernetes version", func() {
-		version, err := utils.GetKubernetesVersion(context.TODO(), testEnv.Config,
+		version, err := k8s_utils.GetKubernetesVersion(context.TODO(), testEnv.Config,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(version).ToNot(BeEmpty())

--- a/lib/patcher/patcher_test.go
+++ b/lib/patcher/patcher_test.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	sveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	"github.com/projectsveltos/libsveltos/lib/patcher"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var (
@@ -138,13 +138,13 @@ metadata:
   name: my-serviceaccount
   namespace: my-test`
 
-			namespace, err := utils.GetUnstructured([]byte(nsYAML))
+			namespace, err := k8s_utils.GetUnstructured([]byte(nsYAML))
 			Expect(err).To(BeNil())
 
-			sa, err := utils.GetUnstructured([]byte(saYAML))
+			sa, err := k8s_utils.GetUnstructured([]byte(saYAML))
 			Expect(err).To(BeNil())
 
-			pod, err := utils.GetUnstructured([]byte(podYAML))
+			pod, err := k8s_utils.GetUnstructured([]byte(podYAML))
 			Expect(err).To(BeNil())
 
 			outputObjects, err := renderer.RunUnstructured([]*unstructured.Unstructured{namespace, sa, pod})

--- a/lib/roles/roles.go
+++ b/lib/roles/roles.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 const (
@@ -118,7 +118,7 @@ func DeleteSecret(ctx context.Context, c client.Client,
 	}
 
 	for i := range secretList.Items {
-		deployer.RemoveOwnerReference(&secretList.Items[i], owner)
+		k8s_utils.RemoveOwnerReference(&secretList.Items[i], owner)
 
 		if len(secretList.Items[i].GetOwnerReferences()) != 0 {
 			err = c.Update(ctx, &secretList.Items[i])
@@ -156,7 +156,7 @@ func ListSecretForOwner(ctx context.Context, c client.Client, owner client.Objec
 
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
-		if deployer.IsOwnerReference(secret, owner) {
+		if k8s_utils.IsOwnerReference(secret, owner) {
 			results = append(results, *secret)
 		}
 	}
@@ -295,7 +295,7 @@ func getListOptionsForSecret(clusterNamespace, clusterName, serviceAccountNamesp
 // - kubeconfig stored in the secret and the new kubeconfig are different;
 // - owner is currently not one of the secret's ownerReferences
 func shouldUpdate(secret *corev1.Secret, kubeconfig []byte, owner client.Object) bool {
-	if !deployer.IsOwnerReference(secret, owner) {
+	if !k8s_utils.IsOwnerReference(secret, owner) {
 		return true
 	}
 
@@ -310,7 +310,7 @@ func shouldUpdate(secret *corev1.Secret, kubeconfig []byte, owner client.Object)
 func updateSecret(ctx context.Context, c client.Client, secret *corev1.Secret,
 	kubeconfig []byte, owner client.Object) (*corev1.Secret, error) {
 
-	deployer.AddOwnerReference(secret, owner)
+	k8s_utils.AddOwnerReference(secret, owner)
 
 	secret.Data = map[string][]byte{
 		key: kubeconfig,

--- a/lib/roles/roles_test.go
+++ b/lib/roles/roles_test.go
@@ -14,8 +14,8 @@ import (
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/crd"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	"github.com/projectsveltos/libsveltos/lib/roles"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var _ = Describe("Roles", func() {
@@ -145,7 +145,7 @@ var _ = Describe("Roles", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		roleRequestCRD, err := utils.GetUnstructured(crd.GetRoleRequestCRDYAML())
+		roleRequestCRD, err := k8s_utils.GetUnstructured(crd.GetRoleRequestCRDYAML())
 		Expect(err).To(BeNil())
 		Expect(c.Create(context.TODO(), roleRequestCRD)).To(Succeed())
 


### PR DESCRIPTION
That information is useful to display diff in case of update while in DryRun mode.

Rename the `utils` package to `k8s_utils`