### PR TITLE
(chore) enhance logging for compatibility checks

### DIFF
--- a/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/textlogger"
 
 	"github.com/projectsveltos/libsveltos/lib/sveltos_upgrade"
 
@@ -87,9 +88,9 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
-
-		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, version)).To(BeTrue())
-		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, randomString())).To(BeFalse())
+		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, version, logger)).To(BeTrue())
+		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, randomString(), logger)).To(BeFalse())
 	})
 })
 
@@ -109,9 +110,9 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
-
-		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, version)).To(BeTrue())
-		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, randomString())).To(BeFalse())
+		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, version, logger)).To(BeTrue())
+		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, randomString(), logger)).To(BeFalse())
 	})
 
 	It("Create ConfigMap with drift-detection-manager version", func() {


### PR DESCRIPTION
If there is any issue, this PR adds the exact reason why compatibility checks are failing.
Before this PR there only was a message, "compatibility checks failed" with no extra information on why.

This PR logs:
1. whether ConfigMap is not found
2. whether the ConfigMap.Data is empty
3. whether the expected version is not matching the version in the ConfigMap