### PR TITLE
Use sprig.TxtFuncMap for YAML compatibility

### DIFF
--- a/lib/funcmap/funcmap.go
+++ b/lib/funcmap/funcmap.go
@@ -42,7 +42,7 @@ import (
 
 // TxtFuncMap returns an aggregated template function map. Currently (custom functions + sprig)
 func SveltosFuncMap() template.FuncMap {
-	funcMap := sprig.FuncMap()
+	funcMap := sprig.TxtFuncMap()
 
 	extraFuncs := template.FuncMap{
 		"toToml":        toTOML,


### PR DESCRIPTION
ref: https://github.com/projectsveltos/libsveltos/issues/434

Switch from sprig.FuncMap to sprig.TxtFuncMap as the generated text is YAML, not HTML.