### PR TITLE
(chore) store default classifier and debugging configuration

### DIFF
--- a/configuration/default-classifier.yaml
+++ b/configuration/default-classifier.yaml
@@ -1,0 +1,8 @@
+apiVersion: lib.projectsveltos.io/v1beta1
+kind: Classifier
+metadata:
+  name: default-classifier
+spec:
+  classifierLabels:
+   - key: sveltos-agent
+     value: present

--- a/configuration/default-debuggingconfiguration.yaml
+++ b/configuration/default-debuggingconfiguration.yaml
@@ -1,0 +1,24 @@
+apiVersion: lib.projectsveltos.io/v1beta1
+kind: DebuggingConfiguration
+metadata:
+  name: default
+spec:
+  configuration:
+  - component: AccessManager
+    logLevel: LogLevelInfo
+  - component: AddonManager
+    logLevel: LogLevelInfo
+  - component: Classifier
+    logLevel: LogLevelInfo
+  - component: DriftDetectionManager
+    logLevel: LogLevelInfo
+  - component: EventManager
+    logLevel: LogLevelInfo
+  - component: HealthCheckManager
+    logLevel: LogLevelInfo
+  - component: SveltosClusterManager
+    logLevel: LogLevelInfo
+  - component: UIBackend
+    logLevel: LogLevelInfo
+  - component: ClassifierAgent
+    logLevel: LogLevelInfo


### PR DESCRIPTION
Store default instances

Default classifier is needed for sveltos-agent to be deployed. Default debuggingconfiguration instance is needed to shipd Sveltos with log level set to Info

Part of #435 