### PR TITLE
(feat) rename clusterCheck to ReadinessChecks and LivenessChecks

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2961,7 +2961,8 @@ func autoConvert_v1beta1_SveltosClusterSpec_To_v1alpha1_SveltosClusterSpec(in *v
 	out.ArbitraryData = *(*map[string]string)(unsafe.Pointer(&in.ArbitraryData))
 	out.ActiveWindow = (*ActiveWindow)(unsafe.Pointer(in.ActiveWindow))
 	out.ConsecutiveFailureThreshold = in.ConsecutiveFailureThreshold
-	// WARNING: in.ClusterChecks requires manual conversion: does not exist in peer-type
+	// WARNING: in.ReadinessChecks requires manual conversion: does not exist in peer-type
+	// WARNING: in.LivenessChecks requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta1/sveltoscluster_type.go
+++ b/api/v1beta1/sveltoscluster_type.go
@@ -59,7 +59,7 @@ type ClusterCheck struct {
 	// This field is  used to specify a Lua function that will be used to evaluate
 	// this check.
 	// The function will receive the array of resources selected by ResourceSelectors.
-	// The Lua function must return a struct with:
+	// The Lua function name is evaluate and must return a struct with:
 	// - "result" field: boolean indicating whether check passed or failed;
 	// - "message" field: (optional) message.
 	Condition string `json:"condition"`
@@ -121,10 +121,15 @@ type SveltosClusterSpec struct {
 	// +optional
 	ConsecutiveFailureThreshold int `json:"consecutiveFailureThreshold,omitempty"`
 
-	// ClusterCheck is an optional list of custom checks to verify cluster
+	// ReadinessChecks is an optional list of custom checks to verify cluster
 	// readiness
 	// +optional
-	ClusterChecks []ClusterCheck `json:"clusterChecks,omitempty"`
+	ReadinessChecks []ClusterCheck `json:"readinessChecks,omitempty"`
+
+	// LivenessChecks is an optional list of custom checks to verify cluster
+	// is healthy
+	// +optional
+	LivenessChecks []ClusterCheck `json:"livenessChecks,omitempty"`
 }
 
 // SveltosClusterStatus defines the status of SveltosCluster

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -2198,8 +2198,15 @@ func (in *SveltosClusterSpec) DeepCopyInto(out *SveltosClusterSpec) {
 		*out = new(ActiveWindow)
 		**out = **in
 	}
-	if in.ClusterChecks != nil {
-		in, out := &in.ClusterChecks, &out.ClusterChecks
+	if in.ReadinessChecks != nil {
+		in, out := &in.ReadinessChecks, &out.ReadinessChecks
+		*out = make([]ClusterCheck, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.LivenessChecks != nil {
+		in, out := &in.LivenessChecks, &out.LivenessChecks
 		*out = make([]ClusterCheck, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
@@ -225,10 +225,34 @@ spec:
                 - from
                 - to
                 type: object
-              clusterChecks:
+              consecutiveFailureThreshold:
+                default: 3
                 description: |-
-                  ClusterCheck is an optional list of custom checks to verify cluster
-                  readiness
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
+              data:
+                additionalProperties:
+                  type: string
+                description: ArbitraryData allows for arbitrary nested structures
+                type: object
+              kubeconfigKeyName:
+                description: |-
+                  KubeconfigKeyName specifies the key within the Secret that holds the kubeconfig.
+                  If not specified, Sveltos will use first key in the Secret.
+                type: string
+              kubeconfigName:
+                description: |-
+                  KubeconfigName allows overriding the default Sveltos convention which expected a valid kubeconfig
+                  to be hosted in a secret with the pattern ${sveltosClusterName}-sveltos-kubeconfig.
+
+                  When a value is specified, the referenced Kubernetes Secret object must exist,
+                  and will be used to connect to the Kubernetes cluster.
+                type: string
+              livenessChecks:
+                description: |-
+                  LivenessChecks is an optional list of custom checks to verify cluster
+                  is healthy
                 items:
                   properties:
                     condition:
@@ -236,7 +260,7 @@ spec:
                         This field is  used to specify a Lua function that will be used to evaluate
                         this check.
                         The function will receive the array of resources selected by ResourceSelectors.
-                        The Lua function must return a struct with:
+                        The Lua function name is evaluate and must return a struct with:
                         - "result" field: boolean indicating whether check passed or failed;
                         - "message" field: (optional) message.
                       type: string
@@ -314,35 +338,100 @@ spec:
                   - resourceSelectors
                   type: object
                 type: array
-              consecutiveFailureThreshold:
-                default: 3
-                description: |-
-                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
-                  failures before setting the problem status in Status.ConnectionStatus
-                type: integer
-              data:
-                additionalProperties:
-                  type: string
-                description: ArbitraryData allows for arbitrary nested structures
-                type: object
-              kubeconfigKeyName:
-                description: |-
-                  KubeconfigKeyName specifies the key within the Secret that holds the kubeconfig.
-                  If not specified, Sveltos will use first key in the Secret.
-                type: string
-              kubeconfigName:
-                description: |-
-                  KubeconfigName allows overriding the default Sveltos convention which expected a valid kubeconfig
-                  to be hosted in a secret with the pattern ${sveltosClusterName}-sveltos-kubeconfig.
-
-                  When a value is specified, the referenced Kubernetes Secret object must exist,
-                  and will be used to connect to the Kubernetes cluster.
-                type: string
               paused:
                 description: |-
                   Paused can be used to prevent controllers from processing the
                   SveltosCluster and all its associated objects.
                 type: boolean
+              readinessChecks:
+                description: |-
+                  ReadinessChecks is an optional list of custom checks to verify cluster
+                  readiness
+                items:
+                  properties:
+                    condition:
+                      description: |-
+                        This field is  used to specify a Lua function that will be used to evaluate
+                        this check.
+                        The function will receive the array of resources selected by ResourceSelectors.
+                        The Lua function name is evaluate and must return a struct with:
+                        - "result" field: boolean indicating whether check passed or failed;
+                        - "message" field: (optional) message.
+                      type: string
+                    name:
+                      description: |-
+                        Name of the cluster check.
+                        Must be a DNS_LABEL and unique within the ClusterChecks.
+                      type: string
+                    resourceSelectors:
+                      description: ResourceSelectors identifies what Kubernetes resources
+                        to select
+                      items:
+                        description: ResourceSelector defines what resources are a
+                          match
+                        properties:
+                          evaluate:
+                            description: |-
+                              Evaluate contains a function "evaluate" in lua language.
+                              The function will be passed one of the object selected based on
+                              above criteria.
+                              Must return struct with field "matching" representing whether
+                              object is a match and an optional "message" field.
+                            type: string
+                          group:
+                            description: Group of the resource deployed in the Cluster.
+                            type: string
+                          kind:
+                            description: Kind of the resource deployed in the Cluster.
+                            minLength: 1
+                            type: string
+                          labelFilters:
+                            description: LabelFilters allows to filter resources based
+                              on current labels.
+                            items:
+                              properties:
+                                key:
+                                  description: Key is the label key
+                                  type: string
+                                operation:
+                                  description: Operation is the comparison operation
+                                  enum:
+                                  - Equal
+                                  - Different
+                                  type: string
+                                value:
+                                  description: Value is the label value
+                                  type: string
+                              required:
+                              - key
+                              - operation
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            description: Name of the resource deployed in the  Cluster.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the resource deployed in the  Cluster.
+                              Empty for resources scoped at cluster level.
+                              For namespaced resources, an empty string "" indicates all namespaces.
+                            type: string
+                          version:
+                            description: Version of the resource deployed in the Cluster.
+                            type: string
+                        required:
+                        - group
+                        - kind
+                        - version
+                        type: object
+                      type: array
+                  required:
+                  - condition
+                  - name
+                  - resourceSelectors
+                  type: object
+                type: array
               tokenRequestRenewalOption:
                 description: TokenRequestRenewalOption contains options describing
                   how to renew TokenRequest

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
@@ -224,10 +224,34 @@ spec:
                 - from
                 - to
                 type: object
-              clusterChecks:
+              consecutiveFailureThreshold:
+                default: 3
                 description: |-
-                  ClusterCheck is an optional list of custom checks to verify cluster
-                  readiness
+                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
+                  failures before setting the problem status in Status.ConnectionStatus
+                type: integer
+              data:
+                additionalProperties:
+                  type: string
+                description: ArbitraryData allows for arbitrary nested structures
+                type: object
+              kubeconfigKeyName:
+                description: |-
+                  KubeconfigKeyName specifies the key within the Secret that holds the kubeconfig.
+                  If not specified, Sveltos will use first key in the Secret.
+                type: string
+              kubeconfigName:
+                description: |-
+                  KubeconfigName allows overriding the default Sveltos convention which expected a valid kubeconfig
+                  to be hosted in a secret with the pattern ${sveltosClusterName}-sveltos-kubeconfig.
+
+                  When a value is specified, the referenced Kubernetes Secret object must exist,
+                  and will be used to connect to the Kubernetes cluster.
+                type: string
+              livenessChecks:
+                description: |-
+                  LivenessChecks is an optional list of custom checks to verify cluster
+                  is healthy
                 items:
                   properties:
                     condition:
@@ -235,7 +259,7 @@ spec:
                         This field is  used to specify a Lua function that will be used to evaluate
                         this check.
                         The function will receive the array of resources selected by ResourceSelectors.
-                        The Lua function must return a struct with:
+                        The Lua function name is evaluate and must return a struct with:
                         - "result" field: boolean indicating whether check passed or failed;
                         - "message" field: (optional) message.
                       type: string
@@ -313,35 +337,100 @@ spec:
                   - resourceSelectors
                   type: object
                 type: array
-              consecutiveFailureThreshold:
-                default: 3
-                description: |-
-                  ConsecutiveFailureThreshold is the maximum number of consecutive connection
-                  failures before setting the problem status in Status.ConnectionStatus
-                type: integer
-              data:
-                additionalProperties:
-                  type: string
-                description: ArbitraryData allows for arbitrary nested structures
-                type: object
-              kubeconfigKeyName:
-                description: |-
-                  KubeconfigKeyName specifies the key within the Secret that holds the kubeconfig.
-                  If not specified, Sveltos will use first key in the Secret.
-                type: string
-              kubeconfigName:
-                description: |-
-                  KubeconfigName allows overriding the default Sveltos convention which expected a valid kubeconfig
-                  to be hosted in a secret with the pattern ${sveltosClusterName}-sveltos-kubeconfig.
-
-                  When a value is specified, the referenced Kubernetes Secret object must exist,
-                  and will be used to connect to the Kubernetes cluster.
-                type: string
               paused:
                 description: |-
                   Paused can be used to prevent controllers from processing the
                   SveltosCluster and all its associated objects.
                 type: boolean
+              readinessChecks:
+                description: |-
+                  ReadinessChecks is an optional list of custom checks to verify cluster
+                  readiness
+                items:
+                  properties:
+                    condition:
+                      description: |-
+                        This field is  used to specify a Lua function that will be used to evaluate
+                        this check.
+                        The function will receive the array of resources selected by ResourceSelectors.
+                        The Lua function name is evaluate and must return a struct with:
+                        - "result" field: boolean indicating whether check passed or failed;
+                        - "message" field: (optional) message.
+                      type: string
+                    name:
+                      description: |-
+                        Name of the cluster check.
+                        Must be a DNS_LABEL and unique within the ClusterChecks.
+                      type: string
+                    resourceSelectors:
+                      description: ResourceSelectors identifies what Kubernetes resources
+                        to select
+                      items:
+                        description: ResourceSelector defines what resources are a
+                          match
+                        properties:
+                          evaluate:
+                            description: |-
+                              Evaluate contains a function "evaluate" in lua language.
+                              The function will be passed one of the object selected based on
+                              above criteria.
+                              Must return struct with field "matching" representing whether
+                              object is a match and an optional "message" field.
+                            type: string
+                          group:
+                            description: Group of the resource deployed in the Cluster.
+                            type: string
+                          kind:
+                            description: Kind of the resource deployed in the Cluster.
+                            minLength: 1
+                            type: string
+                          labelFilters:
+                            description: LabelFilters allows to filter resources based
+                              on current labels.
+                            items:
+                              properties:
+                                key:
+                                  description: Key is the label key
+                                  type: string
+                                operation:
+                                  description: Operation is the comparison operation
+                                  enum:
+                                  - Equal
+                                  - Different
+                                  type: string
+                                value:
+                                  description: Value is the label value
+                                  type: string
+                              required:
+                              - key
+                              - operation
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            description: Name of the resource deployed in the  Cluster.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the resource deployed in the  Cluster.
+                              Empty for resources scoped at cluster level.
+                              For namespaced resources, an empty string "" indicates all namespaces.
+                            type: string
+                          version:
+                            description: Version of the resource deployed in the Cluster.
+                            type: string
+                        required:
+                        - group
+                        - kind
+                        - version
+                        type: object
+                      type: array
+                  required:
+                  - condition
+                  - name
+                  - resourceSelectors
+                  type: object
+                type: array
               tokenRequestRenewalOption:
                 description: TokenRequestRenewalOption contains options describing
                   how to renew TokenRequest


### PR DESCRIPTION
Readiness checks are evaluated only until a SveltosCluster reaches the ready state.  A SveltosCluster transitions to the ready state only when all readiness checks pass.

Once a cluster is in the ready state, liveness checks are evaluated periodically.  If all liveness checks pass, the cluster is considered healthy.