### PR TITLE
(feat) Selectively onboard CAPI clusters

### DIFF
--- a/lib/clusterproxy/cluster_utils.go
+++ b/lib/clusterproxy/cluster_utils.go
@@ -388,7 +388,7 @@ func GetListOfClustersForShardKey(ctx context.Context, c client.Client, namespac
 }
 
 func getMatchingCAPIClusters(ctx context.Context, c client.Client, selector labels.Selector,
-	namespace string, logger logr.Logger) ([]corev1.ObjectReference, error) {
+	namespace, onboardAnnotation string, logger logr.Logger) ([]corev1.ObjectReference, error) {
 
 	present, err := isCAPIPresent(ctx, c, logger)
 	if err != nil {
@@ -421,7 +421,7 @@ func getMatchingCAPIClusters(ctx context.Context, c client.Client, selector labe
 			continue
 		}
 
-		if !isCAPIControlPlaneReady(cluster) {
+		if !isCAPIClusterReady(cluster, onboardAnnotation) {
 			// Only ready cluster can match
 			continue
 		}
@@ -490,7 +490,7 @@ func getMatchingSveltosClusters(ctx context.Context, c client.Client, selector l
 
 // GetMatchingClusters returns all Sveltos/CAPI Clusters currently matching selector
 func GetMatchingClusters(ctx context.Context, c client.Client, selector *metav1.LabelSelector,
-	namespace string, logger logr.Logger) ([]corev1.ObjectReference, error) {
+	namespace, capiOnboardAnnotation string, logger logr.Logger) ([]corev1.ObjectReference, error) {
 
 	if selector == nil {
 		logger.V(logs.LogInfo).Info(nilSelectorMessage)
@@ -510,7 +510,8 @@ func GetMatchingClusters(ctx context.Context, c client.Client, selector *metav1.
 		return nil, fmt.Errorf("%w", err)
 	}
 
-	tmpMatching, err := getMatchingCAPIClusters(ctx, c, clusterSelector, namespace, logger)
+	tmpMatching, err := getMatchingCAPIClusters(ctx, c, clusterSelector, namespace,
+		capiOnboardAnnotation, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Deploying Sveltos on a management cluster with hundreds of existing CAPI clusters results in all clusters being onboarded immediately. This can lead to a rapid creation of hundreds of sveltos-agent deployments in the management cluster, potentially causing performance issues.  Therefore, a gradual onboarding mechanism is preferable.

This pull request introduces such a mechanism.  By using an annotation, Sveltos can selectively identify which CAPI clusters to manage. When this annotation is specified, Sveltos will only onboard those CAPI clusters that have it.

This feature allows for gradual onboarding, which is particularly beneficial in management clusters with a large number of pre-existing CAPI clusters.