### PR TITLE
(feat) use onboard annotation only to find matching clusters

### DIFF
--- a/lib/clusterproxy/clusterproxy.go
+++ b/lib/clusterproxy/clusterproxy.go
@@ -250,18 +250,16 @@ func UpdateSveltosSecretData(ctx context.Context, logger logr.Logger, c client.C
 }
 
 // IsClusterReadyToBeConfigured returns true if cluster is ready to be configured
-// capiOnboardAnnotation is the annotation that must be present on CAPI clusters to be
-// managed by Sveltos. Empty capiOnboardAnnotation means consider all existing CAPI clusters.
 func IsClusterReadyToBeConfigured(
 	ctx context.Context, c client.Client, cluster *corev1.ObjectReference,
-	capiOnboardAnnotation string, logger logr.Logger,
+	logger logr.Logger,
 ) (bool, error) {
 
 	if cluster.Kind == libsveltosv1beta1.SveltosClusterKind {
 		return isSveltosClusterReadyToBeConfigured(ctx, c, cluster, logger)
 	}
 
-	return isCAPIClusterReadyToBeConfigured(ctx, c, cluster, capiOnboardAnnotation, logger)
+	return isCAPIClusterReadyToBeConfigured(ctx, c, cluster, logger)
 }
 
 // isSveltosClusterReadyToBeConfigured  returns true if SveltosCluster
@@ -288,11 +286,8 @@ func isSveltosClusterStatusReady(sveltosCluster *libsveltosv1beta1.SveltosCluste
 // isCAPIClusterReadyToBeConfigured checks whether Cluster:
 // - ControlPlaneInitialized condition is set to true on Cluster object or
 // - Status.ControlPlaneReady is set to true
-// - if onboardAnnotation is set, only CAPI clusters that have this exact annotation will be considered
-func isCAPIClusterReadyToBeConfigured(
-	ctx context.Context, c client.Client,
-	cluster *corev1.ObjectReference, onboardAnnotation string, logger logr.Logger,
-) (bool, error) {
+func isCAPIClusterReadyToBeConfigured(ctx context.Context, c client.Client,
+	cluster *corev1.ObjectReference, logger logr.Logger) (bool, error) {
 
 	capiCluster := &clusterv1.Cluster{}
 	err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, capiCluster)
@@ -301,23 +296,10 @@ func isCAPIClusterReadyToBeConfigured(
 		return false, err
 	}
 
-	return isCAPIClusterReady(capiCluster, onboardAnnotation), nil
+	return isCAPIClusterReady(capiCluster), nil
 }
 
-func isCAPIClusterReady(capiCluster *clusterv1.Cluster, onboardAnnotation string) bool {
-	if onboardAnnotation != "" {
-		// To manage Sveltos deployment on a management cluster with numerous existing CAPI clusters,
-		// Sveltos offers selective onboarding.  While Sveltos defaults to onboarding all CAPI clusters,
-		// user can use an annotation to specify which clusters should be managed.  When this annotation is present,
-		// Sveltos will only onboard CAPI clusters that have it.
-		if capiCluster.Annotations == nil {
-			return false
-		}
-		if _, ok := capiCluster.Annotations[onboardAnnotation]; !ok {
-			return false
-		}
-	}
-
+func isCAPIClusterReady(capiCluster *clusterv1.Cluster) bool {
 	for i := range capiCluster.Status.Conditions {
 		c := capiCluster.Status.Conditions[i]
 		if c.Type == clusterv1.ControlPlaneInitializedCondition &&

--- a/lib/clusterproxy/clusterproxy_test.go
+++ b/lib/clusterproxy/clusterproxy_test.go
@@ -225,7 +225,7 @@ var _ = Describe("clusterproxy ", func() {
 
 		ready, err := clusterproxy.IsClusterReadyToBeConfigured(context.TODO(), c,
 			&corev1.ObjectReference{Namespace: cluster.Namespace, Name: cluster.Name, Kind: "Cluster"},
-			"", textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(ready).To(Equal(false))
 	})
@@ -240,7 +240,7 @@ var _ = Describe("clusterproxy ", func() {
 
 		ready, err := clusterproxy.IsClusterReadyToBeConfigured(context.TODO(), c,
 			&corev1.ObjectReference{Namespace: cluster.Namespace, Name: cluster.Name},
-			"", textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(ready).To(Equal(true))
 	})
@@ -261,47 +261,10 @@ var _ = Describe("clusterproxy ", func() {
 
 		ready, err := clusterproxy.IsClusterReadyToBeConfigured(context.TODO(), c,
 			&corev1.ObjectReference{Namespace: cluster.Namespace, Name: cluster.Name},
-			"", textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(ready).To(Equal(true))
 	})
-
-	It("IsCAPIClusterReadyToBeConfigured returns false for a cluster when ControlPlaneInitialized is true when annotation is required",
-		func() {
-			cluster.Status.Conditions = []clusterv1.Condition{
-				{
-					Type:   clusterv1.ControlPlaneInitializedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			}
-
-			initObjects := []client.Object{
-				cluster,
-			}
-
-			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
-
-			annotation := randomString()
-			ready, err := clusterproxy.IsClusterReadyToBeConfigured(context.TODO(), c,
-				&corev1.ObjectReference{Namespace: cluster.Namespace, Name: cluster.Name},
-				annotation, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
-			Expect(err).To(BeNil())
-			Expect(ready).To(Equal(false))
-
-			// Add the required annotation on the CAPI cluster
-			currentCluster := &clusterv1.Cluster{}
-			Expect(c.Get(context.TODO(),
-				types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, currentCluster)).To(Succeed())
-			currentCluster.Annotations = map[string]string{annotation: randomString()}
-			Expect(c.Update(context.TODO(), currentCluster)).To(Succeed())
-
-			// Verify now cluster is ready
-			ready, err = clusterproxy.IsClusterReadyToBeConfigured(context.TODO(), c,
-				&corev1.ObjectReference{Namespace: cluster.Namespace, Name: cluster.Name},
-				annotation, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
-			Expect(err).To(BeNil())
-			Expect(ready).To(Equal(true))
-		})
 
 	It("UpdateSveltosSecretData updates secret with SveltosCluster kubeconfig", func() {
 		randomData := []byte(randomString())
@@ -486,7 +449,7 @@ var _ = Describe("clusterproxy ", func() {
 				Namespace: sveltosCluster.Namespace,
 				Name:      sveltosCluster.Name,
 				Kind:      libsveltosv1beta1.SveltosClusterKind},
-			"", textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(ready).To(Equal(true))
 
@@ -498,7 +461,7 @@ var _ = Describe("clusterproxy ", func() {
 				Namespace: sveltosCluster.Namespace,
 				Name:      sveltosCluster.Name,
 				Kind:      libsveltosv1beta1.SveltosClusterKind},
-			"", textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(ready).To(Equal(false))
 	})


### PR DESCRIPTION
By using an annotation, Sveltos can selectively identify which CAPI clusters to manage. When this annotation is specified, Sveltos will only onboard those CAPI clusters that have it.

Sveltos now uses annotations for selective CAPI cluster management, rather than readiness checks. Previously, an annotation indicated cluster readiness. Now, readiness is determined independently, and the annotation acts as a filter: only ready clusters with the specified annotation are managed.