### PR TITLE
feat: mgmtagent package for agent in management cluster utilities

### DIFF
--- a/lib/mgmtagent/doc.go
+++ b/lib/mgmtagent/doc.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgmtagent
+
+// Package mgmtagent provides utility functions and types specifically designed
+// for Sveltos agents running within the management cluster.
+
+// In this deployment model, EventSource, HealthCheck, and Reloader instances
+// are not propagated to managed clusters. Instead, the sveltos-agent running
+// in the management cluster is responsible for monitoring these resources.
+// However, not all such resources are relevant to the agent's specific managed
+// cluster.
+//
+// To address this, other Sveltos components within the management cluster
+// (such as the event manager and healthcheck manager) maintain per-cluster
+// ConfigMaps. These ConfigMaps contain the names of the EventSource,
+// HealthCheck, and Reloader instances that the sveltos-agent for a particular
+// managed cluster needs to process.

--- a/lib/mgmtagent/mgmtagent_suite_test.go
+++ b/lib/mgmtagent/mgmtagent_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgmtagent_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestExecutor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Notification Suite")
+}

--- a/lib/mgmtagent/utils.go
+++ b/lib/mgmtagent/utils.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgmtagent
+
+import (
+	"fmt"
+	"strings"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+// Returns the name of the ConfigMap that holds the names of resources
+// (EventSource, HealthCheck, Reloader) intended for a specific managed cluster.
+//
+// The naming convention for this ConfigMap is consistent across Sveltos
+// components running in the management cluster.
+func GetConfigMapName(clusterName string, clusterType libsveltosv1beta1.ClusterType) string {
+	return fmt.Sprintf("%s-%s", clusterName, clusterType)
+}
+
+const (
+	eventSourcePrefix = "eventsource-" // eventSourcePrefix is the prefix used for keys related to EventSource resources in ConfigMaps.
+	healthCheckPrefix = "healthcheck-" // healthCheckPrefix is the prefix used for keys related to HealthCheck resources in ConfigMaps.
+	reloaderPrefix    = "reloader-"    // reloaderPrefix is the prefix used for keys related to Reloader resources in ConfigMaps.
+)
+
+// IsEventSourceEntry checks if a given string `k` starts with the `eventSourcePrefix`.
+// This is used to identify entries in ConfigMaps that refer to EventSource resources.
+func IsEventSourceEntry(k string) bool {
+	return strings.HasPrefix(k, eventSourcePrefix)
+}
+
+// IsHealthCheckEntry checks if a given string `k` starts with the `healthCheckPrefix`.
+// This is used to identify entries in ConfigMaps that refer to HealthCheck resources.
+func IsHealthCheckEntry(k string) bool {
+	return strings.HasPrefix(k, healthCheckPrefix)
+}
+
+// IsReloaderEntry checks if a given string `k` starts with the `reloaderPrefix`.
+// This is used to identify entries in ConfigMaps that refer to Reloader resources.
+func IsReloaderEntry(k string) bool {
+	return strings.HasPrefix(k, reloaderPrefix)
+}
+
+// GetKeyForEventSource generates a key for an EventSource resource by prepending
+// the `eventSourcePrefix` to the provided `eventSourceName`. This key is typically
+// used when storing or retrieving EventSource information in ConfigMaps.
+func GetKeyForEventSource(eventSourceName string) string {
+	return eventSourcePrefix + eventSourceName
+}
+
+// GetKeyForHealthCheck generates a key for a HealthCheck resource by prepending
+// the `healthCheckPrefix` to the provided `eventSourceName`. This key is typically
+// used when storing or retrieving HealthCheck information in ConfigMaps.
+func GetKeyForHealthCheck(healthcheckName string) string {
+	return healthCheckPrefix + healthcheckName
+}
+
+// GetKeyForReloader generates a key for a Reloader resource by prepending
+// the `reloaderPrefix` to the provided `reloaderName`. This key is typically
+// used when storing or retrieving Reloader information in ConfigMaps.
+func GetKeyForReloader(reloaderName string) string {
+	return reloaderPrefix + reloaderName
+}

--- a/lib/mgmtagent/utils_test.go
+++ b/lib/mgmtagent/utils_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgmtagent_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectsveltos/libsveltos/lib/mgmtagent"
+)
+
+var _ = Describe("Mgmtagent", func() {
+	Context("Resource Key Handling", func() {
+		const (
+			testEventSourceName = "my-event-source"
+			testHealthCheckName = "my-health-check"
+			testReloaderName    = "my-reloader"
+		)
+
+		It("should correctly identify EventSource keys", func() {
+			eventSourceKey := mgmtagent.GetKeyForEventSource(testEventSourceName)
+			Expect(strings.HasPrefix(eventSourceKey, "eventsource-")).Should(BeTrue())
+			Expect(mgmtagent.IsEventSourceEntry(eventSourceKey)).Should(BeTrue())
+			Expect(mgmtagent.IsEventSourceEntry("other-" + testEventSourceName)).Should(BeFalse())
+		})
+
+		It("should correctly identify HealthCheck keys", func() {
+			healthCheckKey := mgmtagent.GetKeyForHealthCheck(testHealthCheckName)
+			Expect(strings.HasPrefix(healthCheckKey, "healthcheck-")).Should(BeTrue())
+			Expect(mgmtagent.IsHealthCheckEntry(healthCheckKey)).Should(BeTrue())
+			Expect(mgmtagent.IsHealthCheckEntry("other-" + testHealthCheckName)).Should(BeFalse())
+		})
+
+		It("should correctly identify Reloader keys", func() {
+			reloaderKey := mgmtagent.GetKeyForReloader(testReloaderName)
+			Expect(strings.HasPrefix(reloaderKey, "reloader-")).Should(BeTrue())
+			Expect(mgmtagent.IsReloaderEntry(reloaderKey)).Should(BeTrue())
+			Expect(mgmtagent.IsReloaderEntry("other-" + testReloaderName)).Should(BeFalse())
+		})
+
+		It("should generate the correct key for EventSource", func() {
+			expectedKey := "eventsource-" + testEventSourceName
+			actualKey := mgmtagent.GetKeyForEventSource(testEventSourceName)
+			Expect(actualKey).To(Equal(expectedKey))
+		})
+
+		It("should generate the correct key for HealthCheck", func() {
+			expectedKey := "healthcheck-" + testHealthCheckName
+			actualKey := mgmtagent.GetKeyForHealthCheck(testHealthCheckName)
+			Expect(actualKey).To(Equal(expectedKey))
+		})
+
+		It("should generate the correct key for Reloader", func() {
+			expectedKey := "reloader-" + testReloaderName
+			actualKey := mgmtagent.GetKeyForReloader(testReloaderName)
+			Expect(actualKey).To(Equal(expectedKey))
+		})
+	})
+})


### PR DESCRIPTION
This commit adds a new package named _mgmtagent_.

This package provides utility functions and types specifically designed for Sveltos agents running within the management cluster. It includes functionality for:

- Identifying keys related to EventSource, HealthCheck, and Reloader resources in ConfigMaps.
- Generating keys for these resource types based on their names.

These utilities are intended to simplify the management of resources watched by the management cluster's sveltos-agent and align with the per-cluster ConfigMap strategy used by other Sveltos components.