### PR TITLE
(feat) add helper methods for ConfigMap with EventSource/HealthCheck

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/lib/mgmtagent/utils.go
+++ b/lib/mgmtagent/utils.go
@@ -44,10 +44,20 @@ func IsEventSourceEntry(k string) bool {
 	return strings.HasPrefix(k, eventSourcePrefix)
 }
 
+// IsEventSourceEntryForEventTrigger checks if a given string `k` was created because of a given EventTrigger
+func IsEventSourceEntryForEventTrigger(k, eventTriggerName string) bool {
+	return strings.HasPrefix(k, eventSourcePrefix+eventTriggerName)
+}
+
 // IsHealthCheckEntry checks if a given string `k` starts with the `healthCheckPrefix`.
 // This is used to identify entries in ConfigMaps that refer to HealthCheck resources.
 func IsHealthCheckEntry(k string) bool {
 	return strings.HasPrefix(k, healthCheckPrefix)
+}
+
+// IsHealthCheckEntryForClusterHealthCheck checks if a given string `k` was created because of a given ClusterHealthCheck
+func IsHealthCheckEntryForClusterHealthCheck(k, clusterHealthCheckName string) bool {
+	return strings.HasPrefix(k, healthCheckPrefix+clusterHealthCheckName)
 }
 
 // IsReloaderEntry checks if a given string `k` starts with the `reloaderPrefix`.

--- a/lib/mgmtagent/utils_test.go
+++ b/lib/mgmtagent/utils_test.go
@@ -33,45 +33,59 @@ var _ = Describe("Mgmtagent", func() {
 			testReloaderName    = "my-reloader"
 		)
 
-		It("should correctly identify EventSource keys", func() {
+		It("correctly identify EventSource keys", func() {
 			eventSourceKey := mgmtagent.GetKeyForEventSource(randomString(), testEventSourceName)
 			Expect(strings.HasPrefix(eventSourceKey, "eventsource-")).Should(BeTrue())
 			Expect(mgmtagent.IsEventSourceEntry(eventSourceKey)).Should(BeTrue())
 			Expect(mgmtagent.IsEventSourceEntry("other-" + testEventSourceName)).Should(BeFalse())
 		})
 
-		It("should correctly identify HealthCheck keys", func() {
+		It("correctly identify HealthCheck keys", func() {
 			healthCheckKey := mgmtagent.GetKeyForHealthCheck(randomString(), testHealthCheckName)
 			Expect(strings.HasPrefix(healthCheckKey, "healthcheck-")).Should(BeTrue())
 			Expect(mgmtagent.IsHealthCheckEntry(healthCheckKey)).Should(BeTrue())
 			Expect(mgmtagent.IsHealthCheckEntry("other-" + testHealthCheckName)).Should(BeFalse())
 		})
 
-		It("should correctly identify Reloader keys", func() {
+		It("correctly identify Reloader keys", func() {
 			reloaderKey := mgmtagent.GetKeyForReloader(testReloaderName)
 			Expect(strings.HasPrefix(reloaderKey, "reloader-")).Should(BeTrue())
 			Expect(mgmtagent.IsReloaderEntry(reloaderKey)).Should(BeTrue())
 			Expect(mgmtagent.IsReloaderEntry("other-" + testReloaderName)).Should(BeFalse())
 		})
 
-		It("should generate the correct key for EventSource", func() {
+		It("generate the correct key for EventSource", func() {
 			eventTriggerName := randomString()
 			expectedKey := "eventsource-" + eventTriggerName + "-" + testEventSourceName
 			actualKey := mgmtagent.GetKeyForEventSource(eventTriggerName, testEventSourceName)
 			Expect(actualKey).To(Equal(expectedKey))
 		})
 
-		It("should generate the correct key for HealthCheck", func() {
+		It("generate the correct key for HealthCheck", func() {
 			clusterHealthCheckName := randomString()
 			expectedKey := "healthcheck-" + clusterHealthCheckName + "-" + testHealthCheckName
 			actualKey := mgmtagent.GetKeyForHealthCheck(clusterHealthCheckName, testHealthCheckName)
 			Expect(actualKey).To(Equal(expectedKey))
 		})
 
-		It("should generate the correct key for Reloader", func() {
+		It("generate the correct key for Reloader", func() {
 			expectedKey := "reloader-" + testReloaderName
 			actualKey := mgmtagent.GetKeyForReloader(testReloaderName)
 			Expect(actualKey).To(Equal(expectedKey))
+		})
+
+		It("correctly identify if an Entry is created because of an EventTrigger", func() {
+			eventTriggerName := randomString()
+			eventSourceKey := mgmtagent.GetKeyForEventSource(eventTriggerName, randomString())
+			Expect(mgmtagent.IsEventSourceEntryForEventTrigger(eventSourceKey, eventTriggerName)).To(BeTrue())
+			Expect(mgmtagent.IsEventSourceEntryForEventTrigger(eventSourceKey, randomString())).To(BeFalse())
+		})
+
+		It("correctly identify if an Entry is created because of an ClusterHealthCheck", func() {
+			clusterHealthCheckName := randomString()
+			healthCheckKey := mgmtagent.GetKeyForHealthCheck(clusterHealthCheckName, randomString())
+			Expect(mgmtagent.IsHealthCheckEntryForClusterHealthCheck(healthCheckKey, clusterHealthCheckName)).To(BeTrue())
+			Expect(mgmtagent.IsEventSourceEntryForEventTrigger(healthCheckKey, randomString())).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
When sveltos-agent is deployed in the management cluster, EventSource and HealthCheck instances are not copied to the managed cluster.
A per cluster ConfigMap is created containing the EventSource and HealthCheck instances meant to be evaluated in a given cluster.
This PR add helper methods to identify if an entry was created because of an EventTrigger instance or a ClusterHealthCheck instance.