### PR TITLE
(bug) sveltos-agent in management cluster

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/lib/mgmtagent/utils.go
+++ b/lib/mgmtagent/utils.go
@@ -29,7 +29,7 @@ import (
 // The naming convention for this ConfigMap is consistent across Sveltos
 // components running in the management cluster.
 func GetConfigMapName(clusterName string, clusterType libsveltosv1beta1.ClusterType) string {
-	return fmt.Sprintf("%s-%s", clusterName, clusterType)
+	return fmt.Sprintf("%s-%s", clusterName, strings.ToLower(string(clusterType)))
 }
 
 const (


### PR DESCRIPTION
Fix name of the ConfigMap containing EventSource/HealthCheck and Reloader to watch for a given cluster