### PR TITLE
(bug) ResourceSummary labels

### DIFF
--- a/api/v1beta1/resourcesummary_type.go
+++ b/api/v1beta1/resourcesummary_type.go
@@ -27,13 +27,18 @@ const (
 	ResourceSummaryKind = "ResourceSummary"
 
 	// ClusterSummaryNameLabel is added to all ResourceSummary instances
+	// Deprecated: Use ClusterSummaryNameAnnotation
 	ClusterSummaryNameLabel = "projectsveltos.io/cluster-summary-name"
 
 	// ClusterSummaryNamespaceLabel is added to all ResourceSummary instances
+	// Deprecated: Use ClusterSummaryNamespaceAnnotation
 	ClusterSummaryNamespaceLabel = "projectsveltos.io/cluster-summary-namespace"
 
-	// ClusterSummaryTypeLabel is added to all ResourceSummary instances
-	ClusterSummaryTypeLabel = "projectsveltos.io/cluster-summary-type"
+	// ClusterSummaryNameLabel is added to all ResourceSummary instances
+	ClusterSummaryNameAnnotation = "projectsveltos.io/cluster-summary-name"
+
+	// ClusterSummaryNamespaceLabel is added to all ResourceSummary instances
+	ClusterSummaryNamespaceAnnotation = "projectsveltos.io/cluster-summary-namespace"
 )
 
 type Resource struct {


### PR DESCRIPTION
Deprecate `ClusterSummaryNamespaceLabel` and `ClusterSummaryNameLabel` Replace those with `ClusterSummaryNamespaceAnnotation` and `ClusterSummaryNameAnnotation`

This change is necessary because ClusterSummary names can sometimes exceed 63 characters, which is the maximum length for label values. Annotations do not have this character limit, providing greater flexibility.