### PR TITLE
feat: Add __AgentLastReportTime__ to SveltosClusterStatus for pull mo…

### DIFF
--- a/api/v1beta1/sveltoscluster_type.go
+++ b/api/v1beta1/sveltoscluster_type.go
@@ -175,6 +175,13 @@ type SveltosClusterStatus struct {
 	// +optional
 	LastReconciledTokenRequestAt string `json:"lastReconciledTokenRequestAt,omitempty"`
 
+	// AgentLastReportTime indicates the last time the Sveltos agent in the managed cluster
+	// successfully reported its status to the management cluster's API server.
+	// This field is updated exclusively when Sveltos operates in pull mode,
+	// serving as a heartbeat from the agent's perspective.
+	// +optional
+	AgentLastReportTime *metav1.Time `json:"agentLastReportTime,omitempty"`
+
 	// Information when next unpause cluster is scheduled
 	// +optional
 	NextUnpause *metav1.Time `json:"nextUnpause,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -2611,6 +2611,10 @@ func (in *SveltosClusterStatus) DeepCopyInto(out *SveltosClusterStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AgentLastReportTime != nil {
+		in, out := &in.AgentLastReportTime, &out.AgentLastReportTime
+		*out = (*in).DeepCopy()
+	}
 	if in.NextUnpause != nil {
 		in, out := &in.NextUnpause, &out.NextUnpause
 		*out = (*in).DeepCopy()

--- a/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
@@ -380,6 +380,14 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              agentLastReportTime:
+                description: |-
+                  AgentLastReportTime indicates the last time the Sveltos agent in the managed cluster
+                  successfully reported its status to the management cluster's API server.
+                  This field is updated exclusively when Sveltos operates in pull mode,
+                  serving as a heartbeat from the agent's perspective.
+                format: date-time
+                type: string
               connectionFailures:
                 default: 0
                 description: |-

--- a/lib/crd/sveltosclusters.go
+++ b/lib/crd/sveltosclusters.go
@@ -398,6 +398,14 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              agentLastReportTime:
+                description: |-
+                  AgentLastReportTime indicates the last time the Sveltos agent in the managed cluster
+                  successfully reported its status to the management cluster's API server.
+                  This field is updated exclusively when Sveltos operates in pull mode,
+                  serving as a heartbeat from the agent's perspective.
+                format: date-time
+                type: string
               connectionFailures:
                 default: 0
                 description: |-

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
@@ -379,6 +379,14 @@ spec:
           status:
             description: SveltosClusterStatus defines the status of SveltosCluster
             properties:
+              agentLastReportTime:
+                description: |-
+                  AgentLastReportTime indicates the last time the Sveltos agent in the managed cluster
+                  successfully reported its status to the management cluster's API server.
+                  This field is updated exclusively when Sveltos operates in pull mode,
+                  serving as a heartbeat from the agent's perspective.
+                format: date-time
+                type: string
               connectionFailures:
                 default: 0
                 description: |-


### PR DESCRIPTION
…de heartbeat

This PR introduces a new field, `AgentLastReportTime` (type metav1.Time), to the SveltosCluster's status subresource.

Why this change is needed:
In Sveltos's pull mode, the Sveltos agent running within a managed cluster is responsible for initiating communication back to the management cluster. To enhance observability and provide a clear signal of the agent's health and connectivity from its own perspective, we need a mechanism to track its last successful communication.

This new AgentLastReportTime field will serve as a crucial heartbeat. It indicates the last timestamp when the agent successfully reported its status.