### PR TITLE
(bug) remove owner annotations

### DIFF
--- a/lib/deployer/clean.go
+++ b/lib/deployer/clean.go
@@ -120,6 +120,13 @@ func handleResourceDelete(ctx context.Context, c client.Client, policy client.Ob
 		delete(l, ReferenceNameLabel)
 		delete(l, ReferenceNamespaceLabel)
 		policy.SetLabels(l)
+
+		annotations := policy.GetAnnotations()
+		delete(annotations, OwnerKind)
+		delete(annotations, OwnerName)
+		delete(annotations, OwnerTier)
+		policy.SetAnnotations(annotations)
+
 		return c.Update(ctx, policy)
 	}
 


### PR DESCRIPTION
When profile stops matching a cluster, resources deployed because of that profile are removed.
If profile StopMatchingBehavior is set to LeavePolicies, resources are left on cluster. But labels and annotations indicating reason those resources were deployed must be cleared.

This PR makes sure owner annotations are cleared.