### PR TITLE
(feat) introduce UpdatePhase to ConfigurationGroup

### DIFF
--- a/api/v1beta1/configurationgroup_type.go
+++ b/api/v1beta1/configurationgroup_type.go
@@ -48,6 +48,17 @@ const (
 	ActionRemove = Action("Remove")
 )
 
+// +kubebuilder:validation:Enum:=Ready;Preparing
+type UpdatePhase string
+
+const (
+	// UpdatePhaseReady indicates the ConfigurationGroup is ready for deployment
+	UpdatePhaseReady = UpdatePhase("Ready")
+
+	// UpdatePhasePreparing indicates a new version of the ConfigurationGroup is being prepared
+	UpdatePhasePreparing = UpdatePhase("Preparing")
+)
+
 type ConfigurationGroupSpec struct {
 	// +kubebuilder:default:=Deploy
 	Action Action `json:"action,omitempty"`
@@ -147,6 +158,15 @@ type ConfigurationGroupSpec struct {
 	// Each element has format kind.version.group
 	// +optional
 	DeployedGroupVersionKind []string `json:"deployedGroupVersionKind,omitempty"`
+
+	// UpdatePhase indicates the current phase of configuration updates. When set to "Preparing",
+	// it signals that a new version of this ConfigurationGroup is being prepared, forcing
+	// metadata.generation to advance. This allows detection of differences between
+	// status.observedGeneration and metadata.generation when agents process an older version,
+	// enabling tracking of update propagation across managed clusters.
+	// +kubebuilder:default:=Ready
+	// +optional
+	UpdatePhase UpdatePhase `json:"updatePhase,omitempty"`
 }
 
 type ConfigurationGroupStatus struct {

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -283,6 +283,18 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              updatePhase:
+                default: Ready
+                description: |-
+                  UpdatePhase indicates the current phase of configuration updates. When set to "Preparing",
+                  it signals that a new version of this ConfigurationGroup is being prepared, forcing
+                  metadata.generation to advance. This allows detection of differences between
+                  status.observedGeneration and metadata.generation when agents process an older version,
+                  enabling tracking of update propagation across managed clusters.
+                enum:
+                - Ready
+                - Preparing
+                type: string
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of Lua functions to run against

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -301,6 +301,18 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              updatePhase:
+                default: Ready
+                description: |-
+                  UpdatePhase indicates the current phase of configuration updates. When set to "Preparing",
+                  it signals that a new version of this ConfigurationGroup is being prepared, forcing
+                  metadata.generation to advance. This allows detection of differences between
+                  status.observedGeneration and metadata.generation when agents process an older version,
+                  enabling tracking of update propagation across managed clusters.
+                enum:
+                - Ready
+                - Preparing
+                type: string
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of Lua functions to run against

--- a/lib/pullmode/apis.go
+++ b/lib/pullmode/apis.go
@@ -154,6 +154,12 @@ func StageResourcesForDeployment(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, requestorKind, requestorName, requestorFeature string,
 	resources map[string][]unstructured.Unstructured, skipTracking bool, logger logr.Logger) error {
 
+	err := markConfigurationGroupAsPreparing(ctx, c, clusterNamespace, clusterName, requestorKind,
+		requestorName, requestorFeature, logger)
+	if err != nil {
+		return err
+	}
+
 	// Create all ConfigurationBundles. There one configurationBundle per key.
 	// If Requestor is ClusterSummary each key represents a different ConfigMap/Secret referenced in
 	// policyRef section or a different helm chart in the helmChart section.

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -282,6 +282,18 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              updatePhase:
+                default: Ready
+                description: |-
+                  UpdatePhase indicates the current phase of configuration updates. When set to "Preparing",
+                  it signals that a new version of this ConfigurationGroup is being prepared, forcing
+                  metadata.generation to advance. This allows detection of differences between
+                  status.observedGeneration and metadata.generation when agents process an older version,
+                  enabling tracking of update propagation across managed clusters.
+                enum:
+                - Ready
+                - Preparing
+                type: string
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of Lua functions to run against


### PR DESCRIPTION
ConfigurationGroup instances are prepared by Sveltos components in the management cluster and processed by sveltos-applier in managed clusters.

When a ConfigurationGroup is being updated (for instance, new ConfigurationBundles are being prepared), there's a timing issue: if sveltos-applier finishes processing the old instance while the update is in progress, we need to detect that the processed version is stale.

The UpdatePhase field addresses this by:
- Setting to "Preparing" when updates begin, advancing metadata.generation
- Allowing detection of stale processing via status.observedGeneration < metadata.generation
- Ensuring sveltos-applier waits for the updated ConfigurationGroup to be "Ready" before processing

This prevents race conditions where agents process outdated configurations during update preparation.