### PR TITLE
(feat) introduce stagedResourceManager

### DIFF
--- a/lib/pullmode/apis_test.go
+++ b/lib/pullmode/apis_test.go
@@ -311,10 +311,10 @@ var _ = Describe("APIs for SveltosCluster instances in pullmode", func() {
 
 		bundleNames := make([]string, 0)
 		for i := 0; i < 3; i++ {
-			bundleName, err := pullmode.ReconcileConfigurationBundle(context.TODO(), k8sClient, clusterNamespace, clusterName,
+			bundle, err := pullmode.ReconcileConfigurationBundle(context.TODO(), k8sClient, clusterNamespace, clusterName,
 				requestorKind, requestorName, requestorFeature, randomString(), nil, false, false, logger)
 			Expect(err).To(BeNil())
-			bundleNames = append(bundleNames, bundleName)
+			bundleNames = append(bundleNames, bundle.Name)
 		}
 
 		labels := pullmode.GetConfigurationGroupLabels(clusterName, requestorKind, requestorFeature)

--- a/lib/pullmode/manager.go
+++ b/lib/pullmode/manager.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pullmode
+
+import (
+	"fmt"
+	"sync"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+type stagedManager struct {
+	mu            sync.RWMutex
+	stagedBundles map[string][]libsveltosv1beta1.ConfigurationBundle
+}
+
+var (
+	instance *stagedManager
+	once     sync.Once
+)
+
+func getStagedResourcesManager() *stagedManager {
+	once.Do(func() {
+		instance = &stagedManager{
+			stagedBundles: make(map[string][]libsveltosv1beta1.ConfigurationBundle),
+		}
+	})
+	return instance
+}
+
+func (s *stagedManager) geKey(clusterNamespace, clusterName, requestorName, requestorFeature string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", clusterNamespace, clusterName, requestorName, requestorFeature)
+}
+
+func (s *stagedManager) storeBundle(clusterNamespace, clusterName, requestorName, requestorFeature string,
+	bundle *libsveltosv1beta1.ConfigurationBundle) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := s.geKey(clusterNamespace, clusterName, requestorName, requestorFeature)
+	s.stagedBundles[key] = append(s.stagedBundles[key], *bundle)
+}
+
+func (s *stagedManager) getBundles(clusterNamespace, clusterName, requestorName, requestorFeature string,
+) []libsveltosv1beta1.ConfigurationBundle {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := s.geKey(clusterNamespace, clusterName, requestorName, requestorFeature)
+	return s.stagedBundles[key]
+}
+
+func (s *stagedManager) clearBundles(clusterNamespace, clusterName, requestorName, requestorFeature string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := s.geKey(clusterNamespace, clusterName, requestorName, requestorFeature)
+	delete(s.stagedBundles, key)
+}


### PR DESCRIPTION
Keep track of staged ConfigurationBundles in memory to avoid cache synchronization issues.

Previously, the flow was:

1. Create ConfigurationBundles in cluster
2. Query ConfigurationBundles from Kubernetes
3. Create ConfigurationGroup based on query results

This caused race conditions where the cache didn't return all recently created ConfigurationBundles, leading to incomplete ConfigurationGroups. The staged resource manager maintains an in-memory store of created bundles, eliminating dependency on cache consistency and ensuring all staged resources are available when creating the ConfigurationGroup.

Add logs when staged resources are added/deleted