### PR TITLE
Use separate function to update CRD

### DIFF
--- a/lib/pullmode/export_test.go
+++ b/lib/pullmode/export_test.go
@@ -20,7 +20,6 @@ var (
 	CreateConfigurationBundle       = createConfigurationBundle
 	UpdateConfigurationBundle       = updateConfigurationBundle
 	ReconcileConfigurationBundle    = reconcileConfigurationBundle
-	GetStagedConfigurationBundles   = getStagedConfigurationBundles
 	DeleteStaleConfigurationBundles = deleteStaleConfigurationBundles
 	GetConfigurationBundles         = getConfigurationBundles
 


### PR DESCRIPTION
With previous implementation we used to get very frequently error like this

```
    failureMessage: 'Operation cannot be fulfilled on customresourcedefinitions.apiextensions.k8s.io
      "policyreports.wgpolicyk8s.io": the object has been modified; please apply your
      changes to the latest version and try again'
```

So replace Path, with combination of Get/Update