### PR TITLE
CRD watcher

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/lib/crd/watcher.go
+++ b/lib/crd/watcher.go
@@ -34,7 +34,15 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type handler func(gvk *schema.GroupVersionKind)
+type ChangeType string
+
+const (
+	Add    ChangeType = "add"
+	Delete ChangeType = "delete"
+	Modify ChangeType = "modify"
+)
+
+type handler func(gvk *schema.GroupVersionKind, action ChangeType)
 
 // WatchCustomResourceDefinition starts a watcher for CustomResourceDefinition.
 // When new CRD is added/deleted/modified, invokes the passed handler
@@ -111,7 +119,7 @@ func runCRDInformer(stopCh <-chan struct{}, s cache.SharedIndexInformer, h handl
 					Version: crd.Spec.Versions[i].Name,
 					Kind:    crd.Spec.Names.Kind,
 				}
-				h(gvk)
+				h(gvk, Add)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -128,7 +136,7 @@ func runCRDInformer(stopCh <-chan struct{}, s cache.SharedIndexInformer, h handl
 					Version: crd.Spec.Versions[i].Name,
 					Kind:    crd.Spec.Names.Kind,
 				}
-				h(gvk)
+				h(gvk, Delete)
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -145,7 +153,7 @@ func runCRDInformer(stopCh <-chan struct{}, s cache.SharedIndexInformer, h handl
 					Version: crd.Spec.Versions[i].Name,
 					Kind:    crd.Spec.Names.Kind,
 				}
-				h(gvk)
+				h(gvk, Modify)
 			}
 		},
 	}

--- a/lib/crd/watcher_test.go
+++ b/lib/crd/watcher_test.go
@@ -75,7 +75,7 @@ spec:
     - ct`
 )
 
-func handler(gvk *schema.GroupVersionKind) {
+func handler(gvk *schema.GroupVersionKind, _ crd.ChangeType) {
 	handlerCalled = true
 }
 


### PR DESCRIPTION
WatchCustomResourceDefinition requires now an handler that can be passed the action (add/delete/modify) that happens on CRD being watched.

This is needed because most of the Sveltos services only require to act on add /delete and can ignore modify.