### PR TITLE
Add helm info to ConfigurationBundle

### DIFF
--- a/api/v1beta1/configurationbundle_type.go
+++ b/api/v1beta1/configurationbundle_type.go
@@ -37,6 +37,35 @@ type ConfigurationBundleSpec struct {
 	// ConfigurationGroup is deleted. This is intended for resources like
 	// Sveltos CRDs or the agents Sveltos deploys in the managed clusters.
 	NotTracked bool `json:"notTracked,omitempty"`
+
+	// time to wait for Kubernetes operation (like Jobs for hooks)
+	// +optional
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// HelmReleaseNamespace indicates the namespace of the Helm release
+	// these resources belong to, if any
+	// +optional
+	HelmReleaseNamespace string `json:"helmReleaseNamespace,omitempty"`
+
+	// HelmReleaseName indicates the name of the Helm release
+	// these resources belong to, if any
+	// +optional
+	HelmReleaseName string `json:"helmReleaseName,omitempty"`
+
+	// HelmReleaseUninstall, when true, indicates that these resources are
+	// part of a Helm release uninstallation process.
+	// This can be used to trigger specific cleanup or post-uninstall hooks.
+	// +kubebuilder:default:=false
+	// +optional
+	HelmReleaseUninstall bool `json:"helmReleaseUninstall,omitempty"`
+
+	// IsLastHelmReleaseBundle, when true, indicates that this ConfigurationBundle
+	// is the final bundle in the sequence for the associated Helm release.
+	// This can be used to trigger finalization steps, such as marking the
+	// release as fully deployed or completely uninstalled in external tracking systems.
+	// +kubebuilder:default:=false
+	// +optional
+	IsLastHelmReleaseBundle bool `json:"isLastHelmReleaseBundle,omitempty"`
 }
 
 type ConfigurationBundleStatus struct {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -732,6 +733,11 @@ func (in *ConfigurationBundleSpec) DeepCopyInto(out *ConfigurationBundleSpec) {
 		in, out := &in.Resources, &out.Resources
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/lib.projectsveltos.io_configurationbundles.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationbundles.yaml
@@ -39,6 +39,31 @@ spec:
             type: object
           spec:
             properties:
+              helmReleaseName:
+                description: |-
+                  HelmReleaseName indicates the name of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseNamespace:
+                description: |-
+                  HelmReleaseNamespace indicates the namespace of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseUninstall:
+                default: false
+                description: |-
+                  HelmReleaseUninstall, when true, indicates that these resources are
+                  part of a Helm release uninstallation process.
+                  This can be used to trigger specific cleanup or post-uninstall hooks.
+                type: boolean
+              isLastHelmReleaseBundle:
+                default: false
+                description: |-
+                  IsLastHelmReleaseBundle, when true, indicates that this ConfigurationBundle
+                  is the final bundle in the sequence for the associated Helm release.
+                  This can be used to trigger finalization steps, such as marking the
+                  release as fully deployed or completely uninstalled in external tracking systems.
+                type: boolean
               notTracked:
                 description: |-
                   NotTracked, when true, signifies that the resources managed by the
@@ -55,6 +80,10 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              timeout:
+                description: time to wait for Kubernetes operation (like Jobs for
+                  hooks)
+                type: string
             type: object
           status:
             properties:

--- a/lib/crd/configurationbundles.go
+++ b/lib/crd/configurationbundles.go
@@ -57,6 +57,31 @@ spec:
             type: object
           spec:
             properties:
+              helmReleaseName:
+                description: |-
+                  HelmReleaseName indicates the name of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseNamespace:
+                description: |-
+                  HelmReleaseNamespace indicates the namespace of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseUninstall:
+                default: false
+                description: |-
+                  HelmReleaseUninstall, when true, indicates that these resources are
+                  part of a Helm release uninstallation process.
+                  This can be used to trigger specific cleanup or post-uninstall hooks.
+                type: boolean
+              isLastHelmReleaseBundle:
+                default: false
+                description: |-
+                  IsLastHelmReleaseBundle, when true, indicates that this ConfigurationBundle
+                  is the final bundle in the sequence for the associated Helm release.
+                  This can be used to trigger finalization steps, such as marking the
+                  release as fully deployed or completely uninstalled in external tracking systems.
+                type: boolean
               notTracked:
                 description: |-
                   NotTracked, when true, signifies that the resources managed by the
@@ -73,6 +98,10 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              timeout:
+                description: time to wait for Kubernetes operation (like Jobs for
+                  hooks)
+                type: string
             type: object
           status:
             properties:

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
@@ -38,6 +38,31 @@ spec:
             type: object
           spec:
             properties:
+              helmReleaseName:
+                description: |-
+                  HelmReleaseName indicates the name of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseNamespace:
+                description: |-
+                  HelmReleaseNamespace indicates the namespace of the Helm release
+                  these resources belong to, if any
+                type: string
+              helmReleaseUninstall:
+                default: false
+                description: |-
+                  HelmReleaseUninstall, when true, indicates that these resources are
+                  part of a Helm release uninstallation process.
+                  This can be used to trigger specific cleanup or post-uninstall hooks.
+                type: boolean
+              isLastHelmReleaseBundle:
+                default: false
+                description: |-
+                  IsLastHelmReleaseBundle, when true, indicates that this ConfigurationBundle
+                  is the final bundle in the sequence for the associated Helm release.
+                  This can be used to trigger finalization steps, such as marking the
+                  release as fully deployed or completely uninstalled in external tracking systems.
+                type: boolean
               notTracked:
                 description: |-
                   NotTracked, when true, signifies that the resources managed by the
@@ -54,6 +79,10 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              timeout:
+                description: time to wait for Kubernetes operation (like Jobs for
+                  hooks)
+                type: string
             type: object
           status:
             properties:


### PR DESCRIPTION
Following information can be added:
1. Helm release namespace/name
2. Helm timeout

Also since multiple ConfigurationBundle instances can be created because of an helm chart, the last instance for a given helm chart is marked with a special flag indicating that.