### PR TITLE
(chore) Add new label for EventReport

### DIFF
--- a/api/v1beta1/eventreport_type.go
+++ b/api/v1beta1/eventreport_type.go
@@ -40,6 +40,9 @@ const (
 
 	// EventReportClusterTypeLabel is added to each EventReport
 	EventReportClusterTypeLabel = "eventreport.projectsveltos.io/cluster-type"
+
+	// EventReportPullModeLabel is added to each EventReport from clusters in pull mode
+	EventReportPullModeLabel = "eventreport.projectsveltos.io/pullmode"
 )
 
 func GetEventReportName(healthName, clusterName string, clusterType *ClusterType) string {


### PR DESCRIPTION
This change introduces a new label to EventReport resources. For managed clusters in pull-mode, sveltos-applier collects EventReports from managed cluster and copies them to the management cluster.

To enable the event-manager to efficiently monitor and react to these specific EventReport instances, sveltos-applier automatically attach a this label during the copying process.