### PR TITLE
Add ServiceAccount information to ConfigurationGroup

### DIFF
--- a/api/v1beta1/configurationgroup_type.go
+++ b/api/v1beta1/configurationgroup_type.go
@@ -173,6 +173,20 @@ type ConfigurationGroupSpec struct {
 	// changed and the ConfigurationGroup needs to be updated accordingly.
 	// +optional
 	RequestorHash []byte `json:"requestorHash,omitempty"`
+
+	// ServiceAccountName is the name of the ServiceAccount to impersonate when applying
+	// the configuration. If empty, the default ServiceAccount for the Sveltos-applier
+	// will be used.
+	// The ServiceAccount must exist in the managed cluster.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// ServiceAccountNamespace is the namespace of the ServiceAccount to impersonate when applying
+	// the configuration. If empty, the default namespace for the Sveltos-applier
+	// will be used (typically the same namespace where the Sveltos-applier is deployed).
+	// The ServiceAccount must exist in the managed cluster.
+	// +optional
+	ServiceAccountNamespace string `json:"serviceAccountNamespace,omitempty"`
 }
 
 type ConfigurationGroupStatus struct {

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -229,6 +229,20 @@ spec:
                   changed and the ConfigurationGroup needs to be updated accordingly.
                 format: byte
                 type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default ServiceAccount for the Sveltos-applier
+                  will be used.
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
+              serviceAccountNamespace:
+                description: |-
+                  ServiceAccountNamespace is the namespace of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default namespace for the Sveltos-applier
+                  will be used (typically the same namespace where the Sveltos-applier is deployed).
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
               sourceRef:
                 description: |-
                   SourceRef is the user facing Sveltos resource that caused this ConfigurationGroup to be

--- a/lib/clusterproxy/cluster_utils.go
+++ b/lib/clusterproxy/cluster_utils.go
@@ -138,6 +138,10 @@ func getKubernetesRestConfigForAdmin(ctx context.Context, c client.Client,
 		return nil, err
 	}
 
+	if kubeconfigContent == nil {
+		return nil, nil
+	}
+
 	kubeconfig, closer, err := CreateKubeconfig(logger, kubeconfigContent)
 	if err != nil {
 		return nil, err
@@ -162,6 +166,10 @@ func getKubernetesClientForAdmin(ctx context.Context, c client.Client,
 	if err != nil {
 		return nil, err
 	}
+	if config == nil {
+		return nil, nil
+	}
+
 	logger.V(logsettings.LogVerbose).Info("return new client")
 	return client.New(config, client.Options{Scheme: c.Scheme()})
 }

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -247,6 +247,20 @@ spec:
                   changed and the ConfigurationGroup needs to be updated accordingly.
                 format: byte
                 type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default ServiceAccount for the Sveltos-applier
+                  will be used.
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
+              serviceAccountNamespace:
+                description: |-
+                  ServiceAccountNamespace is the namespace of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default namespace for the Sveltos-applier
+                  will be used (typically the same namespace where the Sveltos-applier is deployed).
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
               sourceRef:
                 description: |-
                   SourceRef is the user facing Sveltos resource that caused this ConfigurationGroup to be

--- a/lib/pullmode/setters.go
+++ b/lib/pullmode/setters.go
@@ -19,6 +19,7 @@ package pullmode
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
@@ -38,6 +39,7 @@ type Options struct {
 	DeployedGVKs           []string
 	Annotations            map[string]string
 	RequestorHash          []byte
+	ServiceAccount         types.NamespacedName
 }
 
 type Option func(*Options)
@@ -126,6 +128,15 @@ func WithAnnotations(annotations map[string]string) Option {
 	}
 }
 
+func WithServiceAccount(namespace, name string) Option {
+	return func(args *Options) {
+		args.ServiceAccount = types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}
+	}
+}
+
 func applySetters(confGroup *libsveltosv1beta1.ConfigurationGroup, setters ...Option,
 ) *libsveltosv1beta1.ConfigurationGroup {
 
@@ -166,6 +177,8 @@ func applySetters(confGroup *libsveltosv1beta1.ConfigurationGroup, setters ...Op
 	confGroup.Spec.MaxConsecutiveFailures = c.MaxConsecutiveFailures
 
 	confGroup.Spec.RequestorHash = c.RequestorHash
+	confGroup.Spec.ServiceAccountNamespace = c.ServiceAccount.Namespace
+	confGroup.Spec.ServiceAccountName = c.ServiceAccount.Name
 
 	return confGroup
 }

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -228,6 +228,20 @@ spec:
                   changed and the ConfigurationGroup needs to be updated accordingly.
                 format: byte
                 type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default ServiceAccount for the Sveltos-applier
+                  will be used.
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
+              serviceAccountNamespace:
+                description: |-
+                  ServiceAccountNamespace is the namespace of the ServiceAccount to impersonate when applying
+                  the configuration. If empty, the default namespace for the Sveltos-applier
+                  will be used (typically the same namespace where the Sveltos-applier is deployed).
+                  The ServiceAccount must exist in the managed cluster.
+                type: string
               sourceRef:
                 description: |-
                   SourceRef is the user facing Sveltos resource that caused this ConfigurationGroup to be


### PR DESCRIPTION
When set, Sveltos-applier will impersonate before applying resources to the managed cluster

This is to support RoleRequests in pull mode.
When RoleRequest is created, access-manager will deploy, via sveltos-applier, a ServiceAccount and associated ClusterRole/Role.

When the labels `projectsveltos.io/serviceaccount-name`and `projectsveltos.io/serviceaccount-namespace` are set on a ClusterProfile/Profile instance, this information is passed to sveltos-applier via ConfigurationGroup.

Sveltos-applier will then impersonate that ServiceAccount before deploying