### PR TITLE
(bug) Preserve order of ConfigurationItems by setting listType to atomic

### DIFF
--- a/api/v1beta1/configurationgroup_type.go
+++ b/api/v1beta1/configurationgroup_type.go
@@ -70,6 +70,8 @@ type ConfigurationGroupSpec struct {
 	SourceRef *corev1.ObjectReference `json:"sourceRef,omitempty"`
 
 	// ConfigurationItems represents a list of configurations to deploy
+	// The order of items in this list determines deployment sequence
+	// +listType=atomic
 	// +optional
 	ConfigurationItems []ConfigurationItem `json:"configurationItem,omitempty"`
 

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -45,8 +45,9 @@ spec:
                 - Remove
                 type: string
               configurationItem:
-                description: ConfigurationItems represents a list of configurations
-                  to deploy
+                description: |-
+                  ConfigurationItems represents a list of configurations to deploy
+                  The order of items in this list determines deployment sequence
                 items:
                   properties:
                     contentRef:
@@ -102,6 +103,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               continueOnConflict:
                 default: false
                 description: |-

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -63,8 +63,9 @@ spec:
                 - Remove
                 type: string
               configurationItem:
-                description: ConfigurationItems represents a list of configurations
-                  to deploy
+                description: |-
+                  ConfigurationItems represents a list of configurations to deploy
+                  The order of items in this list determines deployment sequence
                 items:
                   properties:
                     contentRef:
@@ -120,6 +121,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               continueOnConflict:
                 default: false
                 description: |-

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -44,8 +44,9 @@ spec:
                 - Remove
                 type: string
               configurationItem:
-                description: ConfigurationItems represents a list of configurations
-                  to deploy
+                description: |-
+                  ConfigurationItems represents a list of configurations to deploy
+                  The order of items in this list determines deployment sequence
                 items:
                   properties:
                     contentRef:
@@ -101,6 +102,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               continueOnConflict:
                 default: false
                 description: |-


### PR DESCRIPTION
This PR adds the +listType=atomic marker to the ConfigurationItems field in the ConfigurationGroup CRD to ensure the order of items is preserved during serialization and deserialization.

This is important because the deployment sequence depends on the order of configuration items.