### PR TITLE
Add SourceStatus to ConfigurationGroup

### DIFF
--- a/api/v1beta1/configurationgroup_type.go
+++ b/api/v1beta1/configurationgroup_type.go
@@ -59,6 +59,17 @@ const (
 	UpdatePhasePreparing = UpdatePhase("Preparing")
 )
 
+// SourceStatus defines the lifecycle status of a source resource.
+// +kubebuilder:validation:Enum=Active;Deleted
+type SourceStatus string
+
+const (
+	// SourceStatusActive indicates the source resource is active.
+	SourceStatusActive SourceStatus = "Active"
+	// SourceStatusDeleted indicates the source resource has been deleted.
+	SourceStatusDeleted SourceStatus = "Deleted"
+)
+
 type ConfigurationGroupSpec struct {
 	// +kubebuilder:default:=Deploy
 	Action Action `json:"action,omitempty"`
@@ -68,6 +79,13 @@ type ConfigurationGroupSpec struct {
 	// facing resource is either a ClusterProfile or a Profile.
 	// +optional
 	SourceRef *corev1.ObjectReference `json:"sourceRef,omitempty"`
+
+	// SourceStatus indicates the lifecycle status of the source resource (e.g., ClusterSummary)
+	// that created this ConfigurationGroup. Valid values are "Active" and "Deleted".
+	// This field helps determine if the ConfigurationGroup was created by a source that is
+	// no longer present or in a different state.
+	// +kubebuilder:default:=Active
+	SourceStatus SourceStatus `json:"sourceStatus,omitempty"`
 
 	// ConfigurationItems represents a list of configurations to deploy
 	// The order of items in this list determines deployment sequence

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -291,6 +291,17 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              sourceStatus:
+                default: Active
+                description: |-
+                  SourceStatus indicates the lifecycle status of the source resource (e.g., ClusterSummary)
+                  that created this ConfigurationGroup. Valid values are "Active" and "Deleted".
+                  This field helps determine if the ConfigurationGroup was created by a source that is
+                  no longer present or in a different state.
+                enum:
+                - Active
+                - Deleted
+                type: string
               tier:
                 default: 100
                 description: |-

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -309,6 +309,17 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              sourceStatus:
+                default: Active
+                description: |-
+                  SourceStatus indicates the lifecycle status of the source resource (e.g., ClusterSummary)
+                  that created this ConfigurationGroup. Valid values are "Active" and "Deleted".
+                  This field helps determine if the ConfigurationGroup was created by a source that is
+                  no longer present or in a different state.
+                enum:
+                - Active
+                - Deleted
+                type: string
               tier:
                 default: 100
                 description: |-

--- a/lib/pullmode/setters.go
+++ b/lib/pullmode/setters.go
@@ -26,6 +26,7 @@ import (
 
 type Options struct {
 	SourceRef              *corev1.ObjectReference
+	SourceStatus           libsveltosv1beta1.SourceStatus
 	Tier                   int32
 	DryRun                 bool
 	Reloader               bool
@@ -95,6 +96,12 @@ func WithTier(tier int32) Option {
 func WithSourceRef(sourceRef *corev1.ObjectReference) Option {
 	return func(args *Options) {
 		args.SourceRef = sourceRef
+	}
+}
+
+func WithSourceStatus(sourceStatus libsveltosv1beta1.SourceStatus) Option {
+	return func(args *Options) {
+		args.SourceStatus = sourceStatus
 	}
 }
 
@@ -171,6 +178,7 @@ func applySetters(confGroup *libsveltosv1beta1.ConfigurationGroup, setters ...Op
 	confGroup.Spec.DeployedGroupVersionKind = c.DeployedGVKs
 
 	confGroup.Spec.SourceRef = c.SourceRef
+	confGroup.Spec.SourceStatus = c.SourceStatus
 
 	confGroup.Spec.ContinueOnError = c.ContinueOnError
 	confGroup.Spec.ContinueOnConflict = c.ContinueOnConflict

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -290,6 +290,17 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              sourceStatus:
+                default: Active
+                description: |-
+                  SourceStatus indicates the lifecycle status of the source resource (e.g., ClusterSummary)
+                  that created this ConfigurationGroup. Valid values are "Active" and "Deleted".
+                  This field helps determine if the ConfigurationGroup was created by a source that is
+                  no longer present or in a different state.
+                enum:
+                - Active
+                - Deleted
+                type: string
               tier:
                 default: 100
                 description: |-


### PR DESCRIPTION
It will contain the Status (active vs deleted) of the resource that caused ConfigurationGroup to be created.