### PR TITLE
Remove staged label

### DIFF
--- a/lib/pullmode/apis.go
+++ b/lib/pullmode/apis.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -251,19 +250,6 @@ func CommitStagedResourcesForDeployment(ctx context.Context, c client.Client,
 
 	manager := getStagedResourcesManager()
 	stagedBundles := manager.getBundles(clusterNamespace, clusterName, requestorName, requestorFeature)
-
-	// Remove staged label
-	for i := range stagedBundles {
-		ccb := &stagedBundles[i]
-		if err := removeStagedLabel(ctx, c, ccb); err != nil {
-			logger.V(logsettings.LogInfo).Info(fmt.Sprintf("failed to remove staged label from configurationBundles: %v", err))
-			return err
-		}
-	}
-
-	sort.Slice(stagedBundles, func(i, j int) bool {
-		return stagedBundles[i].CreationTimestamp.Before(&stagedBundles[j].CreationTimestamp)
-	})
 
 	bundles := make([]bundleData, len(stagedBundles))
 	for i := range stagedBundles {

--- a/lib/pullmode/export_test.go
+++ b/lib/pullmode/export_test.go
@@ -31,9 +31,6 @@ var (
 )
 
 const (
-	StagedLabelKey   = stagedLabelKey
-	StagedLabelValue = stagedLabelValue
-
 	RequestorNameAnnotationKey = requestorNameAnnotationKey
 )
 

--- a/lib/pullmode/utils_test.go
+++ b/lib/pullmode/utils_test.go
@@ -196,7 +196,6 @@ var _ = Describe("Utils for pullmode APIs", func() {
 		stagedBundles := make(map[string]bool)
 		for range 4 {
 			bundle := createConfigurationBundle(clusterNamespace, requestorName, labels)
-			bundle.Labels[pullmode.StagedLabelKey] = pullmode.StagedLabelValue
 			Expect(k8sClient.Create(context.TODO(), bundle)).To(Succeed())
 			Expect(waitForObject(context.TODO(), k8sClient, bundle)).To(Succeed())
 			stagedBundles[bundle.Name] = true


### PR DESCRIPTION
ConfigurationBundles created for a given ConfigurationGroup are kept in memory (in a slice, to keep order).
So adding and removing the label was un-necessary operation, remaining from the original implementation.