### PR TITLE
(feat) Add referenced resource data as annotations

### DIFF
--- a/lib/deployer/clean_test.go
+++ b/lib/deployer/clean_test.go
@@ -42,11 +42,14 @@ var _ = Describe("Clean utils", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: randomString(),
 				Name:      randomString(),
+				Annotations: map[string]string{
+					deployer.ReferenceKindAnnotation:      randomString(),
+					deployer.ReferenceNameAnnotation:      randomString(),
+					deployer.ReferenceNamespaceAnnotation: randomString(),
+					randomKey:                             randomValue,
+				},
 				Labels: map[string]string{
-					deployer.ReferenceKindLabel:      randomString(),
-					deployer.ReferenceNameLabel:      randomString(),
-					deployer.ReferenceNamespaceLabel: randomString(),
-					randomKey:                        randomValue,
+					randomKey: randomValue,
 				},
 			},
 		}
@@ -61,8 +64,12 @@ var _ = Describe("Clean utils", func() {
 
 		currentDepl := &appsv1.Deployment{}
 		Expect(c.Get(context.TODO(), types.NamespacedName{Namespace: depl.Namespace, Name: depl.Name}, currentDepl)).To(Succeed())
+		Expect(len(currentDepl.Annotations)).To(Equal(1))
+		v, ok := currentDepl.Annotations[randomKey]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(randomValue))
 		Expect(len(currentDepl.Labels)).To(Equal(1))
-		v, ok := currentDepl.Labels[randomKey]
+		v, ok = currentDepl.Labels[randomKey]
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal(randomValue))
 	})
@@ -74,11 +81,11 @@ var _ = Describe("Clean utils", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: randomString(),
 				Name:      randomString(),
-				Labels: map[string]string{
-					deployer.ReferenceKindLabel:      randomString(),
-					deployer.ReferenceNameLabel:      randomString(),
-					deployer.ReferenceNamespaceLabel: randomString(),
-					randomKey:                        randomValue,
+				Annotations: map[string]string{
+					deployer.ReferenceKindAnnotation:      randomString(),
+					deployer.ReferenceNameAnnotation:      randomString(),
+					deployer.ReferenceNamespaceAnnotation: randomString(),
+					randomKey:                             randomValue,
 				},
 			},
 		}

--- a/lib/deployer/utils.go
+++ b/lib/deployer/utils.go
@@ -19,6 +19,7 @@ package deployer
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,20 +33,43 @@ import (
 )
 
 const (
-	// ReferenceLabelKind is added to each policy deployed by a ClusterSummary
+	// ReferenceKindLabel is added to each policy deployed by a ClusterSummary
 	// instance to a managed Cluster. Indicates the Kind (ConfigMap or Secret)
 	// containing the policy.
+	// Deprecated: replaced by annotation
 	ReferenceKindLabel = "projectsveltos.io/reference-kind"
 
 	// ReferenceNameLabel is added to each policy deployed by a ClusterSummary
 	// instance to a managed Cluster. Indicates the name of the ConfigMap/Secret
 	// containing the policy.
+	// Deprecated: replaced by annotation
 	ReferenceNameLabel = "projectsveltos.io/reference-name"
 
 	// ReferenceNamespaceLabel is added to each policy deployed by a ClusterSummary
 	// instance to a managed Cluster. Indicates the namespace of the ConfigMap/Secret
 	// containing the policy.
+	// Deprecated: replaced by annotation
 	ReferenceNamespaceLabel = "projectsveltos.io/reference-namespace"
+
+	// ReferenceKindAnnotation is added to each policy deployed by a ClusterSummary
+	// instance to a managed Cluster. Indicates the Kind (ConfigMap or Secret)
+	// containing the policy.
+	ReferenceKindAnnotation = "projectsveltos.io/reference-kind"
+
+	// ReferenceNameAnnotation is added to each policy deployed by a ClusterSummary
+	// instance to a managed Cluster. Indicates the name of the ConfigMap/Secret
+	// containing the policy.
+	ReferenceNameAnnotation = "projectsveltos.io/reference-name"
+
+	// ReferenceNamespaceAnnotation is added to each policy deployed by a ClusterSummary
+	// instance to a managed Cluster. Indicates the namespace of the ConfigMap/Secret
+	// containing the policy.
+	ReferenceNamespaceAnnotation = "projectsveltos.io/reference-namespace"
+
+	// ReferenceTierAnnotation is added to each policy deployed by a ClusterSummary
+	// instance to a managed Cluster. Indicates the namespace of the ConfigMap/Secret
+	// containing the policy.
+	ReferenceTierAnnotation = "projectsveltos.io/reference-tier"
 
 	// PolicyHash is the annotation set on a policy when deployed in a managed
 	// cluster.
@@ -129,7 +153,7 @@ func (r *ResourceInfo) GetResourceVersion() string {
 // If object exists, return value of PolicyHash annotation.
 func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 	object *unstructured.Unstructured, referenceKind, referenceNamespace, referenceName string,
-	profile client.Object) (*ResourceInfo, error) {
+	referenceTier int32, profile client.Object) (*ResourceInfo, error) {
 
 	if object == nil {
 		return nil, nil
@@ -154,12 +178,11 @@ func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 		}
 	}
 
-	if labels := currentObject.GetLabels(); labels != nil {
-		kind, kindOk := labels[ReferenceKindLabel]
-		namespace, namespaceOk := labels[ReferenceNamespaceLabel]
-		name, nameOk := labels[ReferenceNameLabel]
+	kind, namespace, name, tier := getReferenceInfo(currentObject)
 
-		if kindOk {
+	// if proposed tier is lower than current tier, do not check for conflict on referenced resource.
+	if referenceTier >= tier {
+		if kind != "" {
 			if kind != referenceKind {
 				return resourceInfo, &ConflictError{
 					message: fmt.Sprintf("A conflict was detected while deploying resource %s:%s/%s. %s"+
@@ -167,8 +190,7 @@ func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 						object.GroupVersionKind().Kind, object.GetNamespace(), object.GetName(),
 						getOwnerMessage(currentObject), kind, namespace, name)}
 			}
-		}
-		if namespaceOk {
+
 			if namespace != referenceNamespace {
 				return resourceInfo, &ConflictError{
 					message: fmt.Sprintf("A conflict was detected while deploying resource %s:%s/%s. %s"+
@@ -176,8 +198,7 @@ func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 						object.GroupVersionKind().Kind, object.GetNamespace(), object.GetName(),
 						getOwnerMessage(currentObject), kind, namespace, name)}
 			}
-		}
-		if nameOk {
+
 			if name != referenceName {
 				return resourceInfo, &ConflictError{
 					message: fmt.Sprintf("A conflict was detected while deploying resource %s:%s/%s. %s"+
@@ -186,21 +207,11 @@ func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 						getOwnerMessage(currentObject), kind, namespace, name)}
 			}
 		}
+	}
 
-		if nameOk {
-			if name != referenceName {
-				return resourceInfo, &ConflictError{
-					message: fmt.Sprintf("A conflict was detected while deploying resource %s:%s/%s. %s"+
-						"This resource is currently deployed because of %s %s/%s.\n",
-						object.GroupVersionKind().Kind, object.GetNamespace(), object.GetName(),
-						getOwnerMessage(currentObject), kind, namespace, name)}
-			}
-		}
-
-		err := validateSveltosOwner(object, currentObject, profile, kind, namespace, name)
-		if err != nil {
-			return resourceInfo, &ConflictError{message: err.Error()}
-		}
+	err = validateSveltosOwner(object, currentObject, profile, kind, namespace, name)
+	if err != nil {
+		return resourceInfo, &ConflictError{message: err.Error()}
 	}
 
 	// Only in case object exists and there are no conflicts, return hash
@@ -209,6 +220,53 @@ func ValidateObjectForUpdate(ctx context.Context, dr dynamic.ResourceInterface,
 	}
 
 	return resourceInfo, nil
+}
+
+// getReferenceInfo extracts the kind, namespace, and name from object annotations
+// and falls back to labels if the annotations are missing or the annotation map is nil.
+func getReferenceInfo(object *unstructured.Unstructured) (kind, namespace, name string, tier int32) {
+	// 1. Attempt to get info from Annotations
+	annotations := object.GetAnnotations()
+	if annotations != nil {
+		kind = annotations[ReferenceKindAnnotation]
+		namespace = annotations[ReferenceNamespaceAnnotation]
+		name = annotations[ReferenceNameAnnotation]
+
+		const defaultTier = 100
+		tier := int32(defaultTier)
+		tierStr, tierOk := annotations[ReferenceTierAnnotation]
+		if tierOk {
+			tier64, err := strconv.ParseInt(tierStr, 10, 32)
+			if err == nil {
+				tier = int32(tier64)
+			}
+			// If ParseInt fails, 'tier' remains the DefaultTier (100)
+		}
+
+		// If we found the kind, we assume the annotation set is complete enough.
+		if kind != "" {
+			return kind, namespace, name, tier
+		}
+	}
+
+	// 2. Fallback to Labels if annotations were nil OR kind was not found in annotations
+	labels := object.GetLabels()
+	if labels != nil {
+		var kindOk bool
+
+		// NOTE: You had a bug in your original prompt's fallback logic where it
+		// still referenced 'annotations'. This is corrected here to use 'labels'.
+		kind, kindOk = labels[ReferenceKindLabel]
+		namespace = labels[ReferenceNamespaceLabel]
+		name = labels[ReferenceNameLabel]
+
+		if kindOk {
+			return kind, namespace, name, tier
+		}
+	}
+
+	// 3. Info not found
+	return "", "", "", tier
 }
 
 func validateSveltosOwner(object, currentObject *unstructured.Unstructured, profile client.Object,


### PR DESCRIPTION
When Sveltos deploys a YAML/JSON (via PolicyRefs or KustomizationRefs) the information on referenced resources were added as labels. This had a downside: the name of the referenced resource cannot exceed 63 characters (that is the maximum length of a label value).

This PR move those data to annotations, removing that limitation.

This PR also introduces a __tier__ concept for PolicyRefs/KustomizationRefs. The Tier field on a Sveltos PolicyRef/KustomizationRef introduces a secondary, intra-profile priority system. It is designed specifically to resolve resource conflicts that occur when multiple policy references within the same parent ClusterProfile or Profile attempt to deploy the identical Kubernetes resource.

This system works in two distinct steps:

1. Primary Conflict Resolution (ClusterProfile Tier)

This is the first and highest-level check.

Scenario: Two different ClusterProfile objects (Profile A and Profile B), both matching the same destination cluster, try to deploy the same resource (e.g., a ConfigMap named my-app-config).

Rule: The ClusterProfile with the lowest numerical Tier value wins. (Lower number = higher priority).

Example: If Profile A has Tier: 10 and Profile B has Tier: 50, Profile A wins and is the only one authorized to manage my-app-config.

2. Secondary Conflict Resolution (PolicyRef Tier)

This is the second-level check, which only happens after a single ClusterProfile has won the primary conflict.

Scenario: One winning ClusterProfile references multiple sources (e.g., PolicyRef 1 pointing to ConfigMap 1, and PolicyRef 2 pointing to ConfigMap 2). Both ConfigMaps contain the same resource (e.g., a Deployment named my-deployment).

Rule: The PolicyRef within the winning ClusterProfile with the lowest numerical Tier value wins and is authorized to deploy/override the resource.

Example: If PolicyRef 1 has Tier: 50 and PolicyRef 2 has Tier: 10 (and both are in the same winning ClusterProfile), PolicyRef 2 wins, allowing ConfigMap 2 to overwrite the Deployment deployed by ConfigMap 1.

Default/Tie-Breaker: If the PolicyRef Tiers are identical, the standard Sveltos order of processing (typically the order of declaration in the list) determines the winner, or a conflict is reported if both try to deploy a new resource simultaneously.