### PR TITLE
EventReport: mark matchingResources with listType=atomic

### DIFF
--- a/api/v1beta1/eventreport_type.go
+++ b/api/v1beta1/eventreport_type.go
@@ -74,6 +74,7 @@ type EventReportSpec struct {
 	EventSourceName string `json:"eventSourceName"`
 
 	// MatchingResources contains a list of resources matching an EventSource
+	// +listType=atomic
 	// +optional
 	MatchingResources []corev1.ObjectReference `json:"matchingResources,omitempty"`
 

--- a/config/crd/bases/lib.projectsveltos.io_eventreports.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventreports.yaml
@@ -113,6 +113,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               resources:
                 description: |-
                   If EventSource Spec.CollectResources is set to true, all matching resources

--- a/lib/crd/eventreports.go
+++ b/lib/crd/eventreports.go
@@ -131,6 +131,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               resources:
                 description: |-
                   If EventSource Spec.CollectResources is set to true, all matching resources

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventreports.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventreports.lib.projectsveltos.io.yaml
@@ -112,6 +112,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               resources:
                 description: |-
                   If EventSource Spec.CollectResources is set to true, all matching resources


### PR DESCRIPTION
A EventSource starts a watcher on specified resources. Any resource change triggers the EventSource to be reprocessed, which discovers all matching resources and updates the EventReport.

When collectResources is set to false, an EventSource might be processed multiple times even if the list of matching resources hasn't changed. Any EventReport update causes event-manager to reprocess it on the control cluster.

To prevent redundant updates to the EventReport the update can be skipped entirely, provided the matching resources are sorted and maintained in a sorted state within the report.