### PR TITLE
(feat) Enhance ResourceSelector with Standard metav1.LabelSelector

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -181,6 +181,14 @@ type ResourceSelector struct {
 	// +optional
 	LabelFilters []LabelFilter `json:"labelFilters,omitempty"`
 
+	// Selector is a standard Kubernetes label selector. Resources are selected
+	// if their labels match the selector. This field uses the standard
+	// Kubernetes label matching syntax (e.g., {"environment": "production"}).
+	// If both LabelFilters and Selector are specified, the requirements from
+	// both are logically ANDed.
+	// +optional
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+
 	// Namespace of the resource deployed in the  Cluster.
 	// Empty for resources scoped at cluster level.
 	// For namespaced resources, an empty string "" indicates all namespaces.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -2063,6 +2063,11 @@ func (in *ResourceSelector) DeepCopyInto(out *ResourceSelector) {
 		in, out := &in.LabelFilters, &out.LabelFilters
 		*out = make([]LabelFilter, len(*in))
 		copy(*out, *in)
+	}
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EvaluateCEL != nil {
 		in, out := &in.EvaluateCEL, &out.EvaluateCEL

--- a/config/crd/bases/lib.projectsveltos.io_classifiers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_classifiers.yaml
@@ -160,6 +160,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string

--- a/config/crd/bases/lib.projectsveltos.io_eventsources.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventsources.yaml
@@ -178,6 +178,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/config/crd/bases/lib.projectsveltos.io_healthchecks.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_healthchecks.yaml
@@ -138,6 +138,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
@@ -200,6 +200,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string
@@ -332,6 +383,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string

--- a/config/crd/bases/lib.projectsveltos.io_techsupports.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_techsupports.yaml
@@ -322,6 +322,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string
@@ -481,6 +532,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string

--- a/lib/crd/classifiers.go
+++ b/lib/crd/classifiers.go
@@ -178,6 +178,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string

--- a/lib/crd/eventsources.go
+++ b/lib/crd/eventsources.go
@@ -196,6 +196,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/lib/crd/healthchecks.go
+++ b/lib/crd/healthchecks.go
@@ -156,6 +156,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/lib/crd/sveltosclusters.go
+++ b/lib/crd/sveltosclusters.go
@@ -218,6 +218,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string
@@ -350,6 +401,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string

--- a/lib/crd/techsupports.go
+++ b/lib/crd/techsupports.go
@@ -340,6 +340,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string
@@ -499,6 +550,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
@@ -159,6 +159,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventsources.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_eventsources.lib.projectsveltos.io.yaml
@@ -177,6 +177,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_healthchecks.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_healthchecks.lib.projectsveltos.io.yaml
@@ -137,6 +137,57 @@ spec:
                         Empty for resources scoped at cluster level.
                         For namespaced resources, an empty string "" indicates all namespaces.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a standard Kubernetes label selector. Resources are selected
+                        if their labels match the selector. This field uses the standard
+                        Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                        If both LabelFilters and Selector are specified, the requirements from
+                        both are logically ANDed.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     version:
                       description: Version of the resource deployed in the Cluster.
                       type: string

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
@@ -199,6 +199,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string
@@ -331,6 +382,57 @@ spec:
                               Empty for resources scoped at cluster level.
                               For namespaced resources, an empty string "" indicates all namespaces.
                             type: string
+                          selector:
+                            description: |-
+                              Selector is a standard Kubernetes label selector. Resources are selected
+                              if their labels match the selector. This field uses the standard
+                              Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                              If both LabelFilters and Selector are specified, the requirements from
+                              both are logically ANDed.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           version:
                             description: Version of the resource deployed in the Cluster.
                             type: string

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_techsupports.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_techsupports.lib.projectsveltos.io.yaml
@@ -321,6 +321,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string
@@ -480,6 +531,57 @@ spec:
                             Empty for resources scoped at cluster level.
                             For namespaced resources, an empty string "" indicates all namespaces.
                           type: string
+                        selector:
+                          description: |-
+                            Selector is a standard Kubernetes label selector. Resources are selected
+                            if their labels match the selector. This field uses the standard
+                            Kubernetes label matching syntax (e.g., {"environment": "production"}).
+                            If both LabelFilters and Selector are specified, the requirements from
+                            both are logically ANDed.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
                         version:
                           description: Version of the resource deployed in the Cluster.
                           type: string


### PR DESCRIPTION
This PR introduces a new field, **Selector**, of type metav1.LabelSelector to the ResourceSelector struct. This enhancement allows users to define resource filtering using the standard Kubernetes label selector syntax, providing a more familiar and powerful method for matching resources.

The existing LabelFilters custom field is retained for backward compatibility.

If both LabelFilters and the new Selector field are defined, the requirements from both are logically **ANDed** together to form the final ListOptions.LabelSelector. This ensures both sets of criteria must be met for a resource to be selected. The combined selector string is passed to the Kubernetes API List call.

Fixes [669](https://github.com/projectsveltos/sveltos/issues/669)