### PR TITLE
(feat) add SkipNamespaceCreation to creation bundle

### DIFF
--- a/api/v1beta1/configurationbundle_type.go
+++ b/api/v1beta1/configurationbundle_type.go
@@ -101,6 +101,16 @@ type ConfigurationBundleSpec struct {
 	// referenced by PolicyRefs/KustomizationRef which contributed to this ConfigurationBundle.
 	// +optional
 	ReferenceTier int32 `json:"referenceTier,omitempty"`
+
+	// SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+	// for namespaced resources defined in this PolicyRef.
+	// This field is ignored for cluster-scoped resources.
+	// By default, Sveltos attempts to get or create the target namespace if it does not exist.
+	// Setting this to true avoids those calls, which is necessary when Sveltos lacks
+	// permissions to manage namespaces at the cluster level.
+	// +kubebuilder:default:=false
+	// +optional
+	SkipNamespaceCreation bool `json:"skipNamespaceCreation,omitempty"`
 }
 
 type ConfigurationBundleStatus struct {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/lib.projectsveltos.io_configurationbundles.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationbundles.yaml
@@ -116,6 +116,16 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              skipNamespaceCreation:
+                default: false
+                description: |-
+                  SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                  for namespaced resources defined in this PolicyRef.
+                  This field is ignored for cluster-scoped resources.
+                  By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                  Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                  permissions to manage namespaces at the cluster level.
+                type: boolean
               timeout:
                 description: time to wait for Kubernetes operation (like Jobs for
                   hooks)

--- a/lib/crd/configurationbundles.go
+++ b/lib/crd/configurationbundles.go
@@ -134,6 +134,16 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              skipNamespaceCreation:
+                default: false
+                description: |-
+                  SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                  for namespaced resources defined in this PolicyRef.
+                  This field is ignored for cluster-scoped resources.
+                  By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                  Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                  permissions to manage namespaces at the cluster level.
+                type: boolean
               timeout:
                 description: time to wait for Kubernetes operation (like Jobs for
                   hooks)

--- a/lib/pullmode/setters.go
+++ b/lib/pullmode/setters.go
@@ -220,6 +220,7 @@ type BundleOptions struct {
 	ReferencedObjectNamespace string
 	ReferencedObjectName      string
 	ReferencedTier            int32
+	SkipNamespaceCreation     bool
 }
 
 type BundleOption func(*BundleOptions)
@@ -255,6 +256,12 @@ func WithResourceInfo(kind, namespace, name string,
 	}
 }
 
+func WithSkipNamespaceCreation(skipNamespaceCreation bool) BundleOption {
+	return func(args *BundleOptions) {
+		args.SkipNamespaceCreation = skipNamespaceCreation
+	}
+}
+
 func applyBundleSetters(confBundle *libsveltosv1beta1.ConfigurationBundle, setters ...BundleOption,
 ) *libsveltosv1beta1.ConfigurationBundle {
 
@@ -281,6 +288,7 @@ func applyBundleSetters(confBundle *libsveltosv1beta1.ConfigurationBundle, sette
 	confBundle.Spec.ReferencedObjectNamespace = c.ReferencedObjectNamespace
 	confBundle.Spec.ReferencedObjectName = c.ReferencedObjectName
 	confBundle.Spec.ReferenceTier = c.ReferencedTier
+	confBundle.Spec.SkipNamespaceCreation = c.SkipNamespaceCreation
 
 	return confBundle
 }

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
@@ -115,6 +115,16 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              skipNamespaceCreation:
+                default: false
+                description: |-
+                  SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                  for namespaced resources defined in this PolicyRef.
+                  This field is ignored for cluster-scoped resources.
+                  By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                  Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                  permissions to manage namespaces at the cluster level.
+                type: boolean
               timeout:
                 description: time to wait for Kubernetes operation (like Jobs for
                   hooks)


### PR DESCRIPTION
When Sveltos deploys resources defined in PolicyRefs or KustomizationRefs, it automatically attempts to "Get" the target namespace and "Create" it if it is missing. While convenient, this behavior forces Sveltos to require cluster-wide get and create permissions for Namespaces.

For many managed production environments, Sveltos might be granted limited RBAC. If a user is operating in a multi-tenant cluster where namespaces are pre-provisioned and Sveltos lacks cluster-level permissions, the deployment currently fails.

Changes:

- Introduced SkipNamespaceCreation to the ConfigurationBundle so to pass sveltos-applier the PolicyRefs and KustomizationRef structs.
- When enabled, Sveltos bypasses the namespace check/creation logic and attempts to deploy resources directly.