### PR TITLE
(chore) re-arrange setters

### DIFF
--- a/lib/pullmode/setters.go
+++ b/lib/pullmode/setters.go
@@ -246,18 +246,13 @@ func WithReleaseInfo(namespace, name, repoURL, chartVersion, icon string,
 }
 
 func WithResourceInfo(kind, namespace, name string,
-	tier int32) BundleOption {
+	tier int32, skipNamespaceCreation bool) BundleOption {
 
 	return func(args *BundleOptions) {
 		args.ReferencedObjectKind = kind
 		args.ReferencedObjectNamespace = namespace
 		args.ReferencedObjectName = name
 		args.ReferencedTier = tier
-	}
-}
-
-func WithSkipNamespaceCreation(skipNamespaceCreation bool) BundleOption {
-	return func(args *BundleOptions) {
 		args.SkipNamespaceCreation = skipNamespaceCreation
 	}
 }


### PR DESCRIPTION
Since skipNamespaceCreation is a property of a PolicyRef or KustomizationRef pass this option in WithResourceInfo