### PR TITLE
Fix data race in ConfigurationBundle name generation

### DIFF
--- a/lib/pullmode/utils.go
+++ b/lib/pullmode/utils.go
@@ -25,15 +25,16 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+	"github.com/projectsveltos/libsveltos/lib/randutils"
 )
 
 const (
@@ -160,7 +161,13 @@ func createConfigurationBundle(ctx context.Context, c client.Client, namespace, 
 
 	err = c.Create(ctx, bundle)
 	if err != nil {
-		return nil, err
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+		// Bundle already exists (e.g. a previous partial cycle created it but never committed).
+		// Fall back to update so the content and annotations are reconciled.
+		return updateConfigurationBundle(ctx, c, namespace, name, requestorName, index,
+			resources, skipTracking, isStaged, logger, setters...)
 	}
 
 	// For staged ConfigurationBundle also stores current hash
@@ -453,7 +460,7 @@ func deleteStaleConfigurationBundles(ctx context.Context, c client.Client,
 	for i := range currentBundles.Items {
 		currentBundle := &currentBundles.Items[i]
 		if _, ok := bundleMap[currentBundle.Name]; !ok {
-			if err := c.Delete(ctx, currentBundle); err != nil {
+			if err := c.Delete(ctx, currentBundle); err != nil && !apierrors.IsNotFound(err) {
 				logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to delete stale configurationBundle: %v", err))
 				return err
 			}
@@ -557,7 +564,7 @@ func getInstantiatedObjectName(objects []client.Object) (name string, currentObj
 		// no configurationBundle exist yet. Return random name.
 		prefix := "config-"
 		const nameLength = 20
-		name = prefix + util.RandomString(nameLength)
+		name = prefix + randutils.RandomString(nameLength)
 		currentObject = nil
 		err = nil
 	case 1:

--- a/lib/randutils/randutils.go
+++ b/lib/randutils/randutils.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package randutils
+
+import (
+	"math/rand"
+)
+
+const (
+	charSet = "0123456789abcdefghijklmnopqrstuvwxyz"
+)
+
+// RandomString returns a goroutine-safe random alphanumeric string of length n.
+// It uses the package-level math/rand source which is goroutine-safe.
+func RandomString(n int) string {
+	result := make([]byte, n)
+	for i := range result {
+		result[i] = charSet[rand.Intn(len(charSet))] //nolint:gosec // used just for name generation
+	}
+	return string(result)
+}


### PR DESCRIPTION
The util.RandomString function from sigs.k8s.io/cluster-api/util uses a package-level rand.Rand without any locking. rand.Rand is not goroutine-safe, so concurrent calls from multiple reconcilers can corrupt its internal state, causing Intn to return 0 for all calls.

Replace the cluster-api util.RandomString call with a local helper that uses the package-level math/rand functions, which are goroutine-safe.

Additionally fix two edge cases in bundle lifecycle management: when deleting stale bundles, ignore NotFound errors since the goal (bundle is gone) is already achieved; when creating a bundle fails with AlreadyExists, fall back to update to reconcile content and annotations rather than failing the whole deploy cycle.