### PR TITLE
(feat) allow configurable namespace for Sveltos

### DIFF
--- a/api/v1beta1/classifierreport_types.go
+++ b/api/v1beta1/classifierreport_types.go
@@ -38,11 +38,10 @@ const (
 
 	ClassifierReportKind = "ClassifierReport"
 
-	// This is the namespace/name of the secret containing the kubeconfig
+	// This is the name of the secret containing the kubeconfig
 	// to send ClassifierReport to management cluster when classifier agent
 	// is configured to send ClassifierReports
-	ClassifierSecretName      = "classifier-agent"
-	ClassifierSecretNamespace = "projectsveltos"
+	ClassifierSecretName = "classifier-agent"
 )
 
 // ReportPhase describes the state of a classifierReport/healthReport/eventReport/reloaderReport.

--- a/lib/licenses/license.go
+++ b/lib/licenses/license.go
@@ -130,11 +130,11 @@ type LicenseVerificationResult struct {
 // and various booleans indicating its validity status, along with a human-readable message.
 // The RawError field will contain any technical errors encountered during the process.
 // Requires permission to read Secret in projectsveltos namespace.
-func VerifyLicenseSecret(ctx context.Context, c client.Client,
+func VerifyLicenseSecret(ctx context.Context, c client.Client, sveltosNamespace string,
 	publicKey *rsa.PublicKey, logger logr.Logger) LicenseVerificationResult {
 
 	secretNsName := types.NamespacedName{
-		Namespace: "projectsveltos",
+		Namespace: sveltosNamespace,
 		Name:      "sveltos-license",
 	}
 

--- a/lib/licenses/license_test.go
+++ b/lib/licenses/license_test.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:lll,gosec // This file has long lines due to signed licenses
+//nolint:lll // This file has long lines due to signed licenses
 package license_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,16 +44,18 @@ var _ = Describe("License", func() {
 	})
 
 	It("Detect Expired License", func() {
+		sveltosNamespace := randomString()
 		// Expired license
-		secret := `apiVersion: v1
+		secret := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
   name: sveltos-license
-  namespace: projectsveltos
+  namespace: %s
 type: Opaque
 data:
   licenseData: eyJpZCI6IjY0Mzk5ZTY3LTdhMjctNDY5MS05YzU1LWY4NmY0YjQ4MGFkOSIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwiZXhwaXJhdGlvbkRhdGUiOiIyMDI0LTA3LTI1VDExOjU3OjIxLjk2MTYwOFoiLCJpc3N1ZWRBdCI6IjIwMjUtMDctMjVUMTE6NTc6MjEuOTYxNjA4WiJ9
-  licenseSignature: Nk+Q3x/ZBg2DydTMcAhGzi8+xCBma4bsLfKXlN5f217/OqJVcfFDqlG3Q46nVRI92i/hOvXVAeEOnBpv8/0iDbUvSZB1fBilkyzglcH00hC7Y3CFF9CnxcmLlqWBl5ucL+MTmzCsgxMHhzklOF4oCMAAbigfty9xVCXE81rQN0jKPktZcVui15uubs7PVgXkvc7+NZrmmchXnECXz912S8ayllRWcgKL482xi8bf9XsKubg+mzQm/S4KvPBR1R8Yugnp1byyZmpzQmNMF1KYC5YT/vVqk7ojVZTPVG9y1SxnpFXGVO+4HRBnbEWoVnifg5U74FcU3kiIgOxpUoylsX88PCfZXdaJT5Mh65cZJVRx1RTYLgnBX260gzaLzuPF33uu5IZ1J182Si5RatkvNdPQd7mtLC2T/lyQK4gMqS2g0iidlxA2iwEeqC/UV42aeXrel3KRJ38TL0SNiCpMLly3ueC5sftdvRWARNel7aV/DAE+nfANIBO9YuLpiJY9EMndr1mpGclMZF6KbXkzOnEqbsiNmXANl7Y2lAKORWElC58IznD0WKFoFuc1ZltUDecGEFoExkdstrIPJ8HYi0dJ0OBaHfQNlo7MjEuHWkmZ1XoeUqMPxjFBrULlX74Lbowqif1lDnZhmZTTJs+qqGYLz424HtcVmir8UD5IboQ=`
+  licenseSignature: Nk+Q3x/ZBg2DydTMcAhGzi8+xCBma4bsLfKXlN5f217/OqJVcfFDqlG3Q46nVRI92i/hOvXVAeEOnBpv8/0iDbUvSZB1fBilkyzglcH00hC7Y3CFF9CnxcmLlqWBl5ucL+MTmzCsgxMHhzklOF4oCMAAbigfty9xVCXE81rQN0jKPktZcVui15uubs7PVgXkvc7+NZrmmchXnECXz912S8ayllRWcgKL482xi8bf9XsKubg+mzQm/S4KvPBR1R8Yugnp1byyZmpzQmNMF1KYC5YT/vVqk7ojVZTPVG9y1SxnpFXGVO+4HRBnbEWoVnifg5U74FcU3kiIgOxpUoylsX88PCfZXdaJT5Mh65cZJVRx1RTYLgnBX260gzaLzuPF33uu5IZ1J182Si5RatkvNdPQd7mtLC2T/lyQK4gMqS2g0iidlxA2iwEeqC/UV42aeXrel3KRJ38TL0SNiCpMLly3ueC5sftdvRWARNel7aV/DAE+nfANIBO9YuLpiJY9EMndr1mpGclMZF6KbXkzOnEqbsiNmXANl7Y2lAKORWElC58IznD0WKFoFuc1ZltUDecGEFoExkdstrIPJ8HYi0dJ0OBaHfQNlo7MjEuHWkmZ1XoeUqMPxjFBrULlX74Lbowqif1lDnZhmZTTJs+qqGYLz424HtcVmir8UD5IboQ=`,
+			sveltosNamespace)
 
 		u, err := k8s_utils.GetUnstructured([]byte(secret))
 		Expect(err).To(BeNil())
@@ -66,22 +69,24 @@ data:
 		publicKey, err := license.GetPublicKey()
 		Expect(err).To(BeNil())
 
-		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, publicKey, logger)
+		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, sveltosNamespace, publicKey, logger)
 		Expect(licenseVerificationResult.RawError).To(BeNil())
 		Expect(licenseVerificationResult.IsExpired).To(BeTrue())
 	})
 
 	It("Get Features from license", func() {
+		sveltosNamespace := randomString()
 		// This contains a valid license (valid for one managed cluster only)
-		secret := `apiVersion: v1
+		secret := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
   name: sveltos-license
-  namespace: projectsveltos
+  namespace: %s
 type: Opaque
 data:
   licenseData: eyJpZCI6IjY0MzNmYzk0LTE2MDYtNGZkOC04YTFkLThjYzg5NjRjOTk0MyIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwiZXhwaXJhdGlvbkRhdGUiOiIyMDI2LTA3LTI1VDExOjU2OjQyLjcyNDIyM1oiLCJtYXhDbHVzdGVycyI6MSwiaXNzdWVkQXQiOiIyMDI1LTA3LTI1VDExOjU2OjQyLjcyNDIyM1oifQ==
-  licenseSignature: ghCbge6VIPr2O0Tvu8jMoEa7HeFBIWxBMOU6L1yq6p1vH7fRQBWGJSEYRH+byUlyXc3MU/mMfmRyphM+X8Birqr25JszIo7n8cps1Ec5FekHo7xBKwXnHp/HWOm6NMohtonCcjU76sd7QTsYbLHujC6NhEObjZzBxBN6TP+m0hYYTufh1gOYBH4BdVFNGlFkqslk1bL4pQo6573okkYilRg+WF+vOKdlidz+pruUcqGvByRsL3OcENN9NItSyP9S2Hkz7Wb0ENfaMhND5jqH8NIfsjNTTE8TeUtTphmUwiRyXV65Tkdv3nLA1ektoSS+fc318KEV0EjIwZPo5Yq7KZls9l7mBKZXj4YSy2Rhj6cD5NOMoAKdt5S82t2amQhWbShCCgWyDOmrBRXiyD9OK8y3TKQ6zQYGCwOYtpCZV+uD1WBdTwhrG0lnGZkfdzkkt4pftMx6YFGopFMLc5/REOPaSWtWGoR9/bwS4s0EWkDCyFrAatxtwhEbOV4pOx5uV2ap/j4v7Ag0PpHJnlnYkW/Z6q5VCov8U1I6OFaCcBoI1MDruubD0qiL2eE25kpTT//cWA/3qxEyh54UqQPeZo6Lno3dW3YlZr62uPXniOzHuOlGWikKK/Wly1gUHfjOUR2PyohC9u3BL9HAZp5IRz4/vXflVqAlv0yWaEbaXHQ=`
+  licenseSignature: ghCbge6VIPr2O0Tvu8jMoEa7HeFBIWxBMOU6L1yq6p1vH7fRQBWGJSEYRH+byUlyXc3MU/mMfmRyphM+X8Birqr25JszIo7n8cps1Ec5FekHo7xBKwXnHp/HWOm6NMohtonCcjU76sd7QTsYbLHujC6NhEObjZzBxBN6TP+m0hYYTufh1gOYBH4BdVFNGlFkqslk1bL4pQo6573okkYilRg+WF+vOKdlidz+pruUcqGvByRsL3OcENN9NItSyP9S2Hkz7Wb0ENfaMhND5jqH8NIfsjNTTE8TeUtTphmUwiRyXV65Tkdv3nLA1ektoSS+fc318KEV0EjIwZPo5Yq7KZls9l7mBKZXj4YSy2Rhj6cD5NOMoAKdt5S82t2amQhWbShCCgWyDOmrBRXiyD9OK8y3TKQ6zQYGCwOYtpCZV+uD1WBdTwhrG0lnGZkfdzkkt4pftMx6YFGopFMLc5/REOPaSWtWGoR9/bwS4s0EWkDCyFrAatxtwhEbOV4pOx5uV2ap/j4v7Ag0PpHJnlnYkW/Z6q5VCov8U1I6OFaCcBoI1MDruubD0qiL2eE25kpTT//cWA/3qxEyh54UqQPeZo6Lno3dW3YlZr62uPXniOzHuOlGWikKK/Wly1gUHfjOUR2PyohC9u3BL9HAZp5IRz4/vXflVqAlv0yWaEbaXHQ=`,
+			sveltosNamespace)
 
 		u, err := k8s_utils.GetUnstructured([]byte(secret))
 		Expect(err).To(BeNil())
@@ -95,7 +100,7 @@ data:
 		publicKey, err := license.GetPublicKey()
 		Expect(err).To(BeNil())
 
-		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, publicKey, logger)
+		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, sveltosNamespace, publicKey, logger)
 		Expect(licenseVerificationResult.RawError).To(BeNil())
 		Expect(licenseVerificationResult.IsExpired).To(BeFalse())
 		Expect(licenseVerificationResult.IsInGracePeriod).To(BeFalse())
@@ -115,16 +120,18 @@ data:
 			},
 		}
 
+		sveltosNamespace := randomString()
 		// This contains a valid license (valid for one managed cluster only) that contains a Cluster fingerprint
-		secret := `apiVersion: v1
+		secret := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
   name: sveltos-license
-  namespace: projectsveltos
+  namespace: %s
 type: Opaque
 data:
   licenseData: eyJpZCI6IjI3NWU2MzUyLTFiYzUtNDUyOC04OTUwLWZhY2Q0MzdlMTI0YyIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwiZXhwaXJhdGlvbkRhdGUiOiIyMDI2LTA3LTI1VDExOjU2OjE2Ljk4MzYxOVoiLCJtYXhDbHVzdGVycyI6MSwiaXNzdWVkQXQiOiIyMDI1LTA3LTI1VDExOjU2OjE2Ljk4MzYxOVoiLCJjbHVzdGVyRmluZ2VycHJpbnQiOiIwMDBjYmFhYi0wODk4LTQ5MzItYTA2Ni04YzVjZmY2Yzk3NTIifQ==
-  licenseSignature: U2LQnSviNdmc7z44DYedZCdg0IGUXvOzk+9rJWu4Rqtph/6e8qBdk2suy0QgftT+NJOB3hdzw1QHSYauw1AZ5EAPMcooSa6P0VVt/Fk9ceJgP+xS63SNogqbSaQadM1GoG5EzF5DpuNvNMxFLXJ9uXCOdt4N/G4k5O7oLTArnkp8cF0897SHnaeUuQBJzsswL4ZYbB3ikLRdXpr/ZW7+rmYc7Y/KpCcAb65LxPWCy28gJm1GP1olM9WkKuiR1z1jOLSgx0UhyATaDxNa60Jkk4RWaTlJMjXNxuEaZ7ptFlrcpV+d/3mSbWlNFKu5/u1iEMO9Jw4BHWKUvT8fpXw1FY07CRdcbHvtOn7Brm2SZCrTmzjFvS1STtgVLErd12f0dqpQ70XNz0q1BlHLVroyMzDFyksonne1KA9GhCNtjRzsXQzImdU/rJYv1bxoWK1c7hSJB4Bht4Gg75WVsjoLIhW0ME9b0E+j/LFukFIVeqb4j+QGDmDJhgvwLvxHl8XZqH/8kyn6rK29sro0Y7Kiqr3NkEsiwQSqj3Rf0nVyutpQBhW5aqEM5eyh1IY8nLYX7gGS3h7FfiPw61tj664w/PwTHIjwsvkpJ9hGbikadDBd3Ihj9Al9x5kCTkNmBpM07+UK3vK2HFYFDSZdAjWmMQx0O1suANKvl0kUu8ptYsw=`
+  licenseSignature: U2LQnSviNdmc7z44DYedZCdg0IGUXvOzk+9rJWu4Rqtph/6e8qBdk2suy0QgftT+NJOB3hdzw1QHSYauw1AZ5EAPMcooSa6P0VVt/Fk9ceJgP+xS63SNogqbSaQadM1GoG5EzF5DpuNvNMxFLXJ9uXCOdt4N/G4k5O7oLTArnkp8cF0897SHnaeUuQBJzsswL4ZYbB3ikLRdXpr/ZW7+rmYc7Y/KpCcAb65LxPWCy28gJm1GP1olM9WkKuiR1z1jOLSgx0UhyATaDxNa60Jkk4RWaTlJMjXNxuEaZ7ptFlrcpV+d/3mSbWlNFKu5/u1iEMO9Jw4BHWKUvT8fpXw1FY07CRdcbHvtOn7Brm2SZCrTmzjFvS1STtgVLErd12f0dqpQ70XNz0q1BlHLVroyMzDFyksonne1KA9GhCNtjRzsXQzImdU/rJYv1bxoWK1c7hSJB4Bht4Gg75WVsjoLIhW0ME9b0E+j/LFukFIVeqb4j+QGDmDJhgvwLvxHl8XZqH/8kyn6rK29sro0Y7Kiqr3NkEsiwQSqj3Rf0nVyutpQBhW5aqEM5eyh1IY8nLYX7gGS3h7FfiPw61tj664w/PwTHIjwsvkpJ9hGbikadDBd3Ihj9Al9x5kCTkNmBpM07+UK3vK2HFYFDSZdAjWmMQx0O1suANKvl0kUu8ptYsw=`,
+			sveltosNamespace)
 
 		u, err := k8s_utils.GetUnstructured([]byte(secret))
 		Expect(err).To(BeNil())
@@ -138,7 +145,7 @@ data:
 		publicKey, err := license.GetPublicKey()
 		Expect(err).To(BeNil())
 
-		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, publicKey, logger)
+		licenseVerificationResult := license.VerifyLicenseSecret(context.TODO(), c, sveltosNamespace, publicKey, logger)
 		Expect(licenseVerificationResult.RawError).To(BeNil())
 		Expect(licenseVerificationResult.IsExpired).To(BeFalse())
 		Expect(licenseVerificationResult.IsInGracePeriod).To(BeFalse())
@@ -151,7 +158,7 @@ data:
 		currentNs.UID = "000cbaab-1234-4932-a111-8c5cff6c9752"
 		Expect(c.Update(context.TODO(), currentNs)).To(Succeed())
 
-		licenseVerificationResult = license.VerifyLicenseSecret(context.TODO(), c, publicKey, logger)
+		licenseVerificationResult = license.VerifyLicenseSecret(context.TODO(), c, sveltosNamespace, publicKey, logger)
 		Expect(licenseVerificationResult.RawError).ToNot(BeNil())
 		Expect(licenseVerificationResult.RawError.Error()).To(ContainSubstring("License is not valid for this cluster (fingerprint mismatch)"))
 	})

--- a/lib/licenses/licenses_suite_test.go
+++ b/lib/licenses/licenses_suite_test.go
@@ -21,9 +21,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controllers Suite")
+}
+
+func randomString() string {
+	const length = 10
+	return util.RandomString(length)
 }

--- a/lib/roles/roles.go
+++ b/lib/roles/roles.go
@@ -227,7 +227,7 @@ func GetServiceAccountNameInManagedCluster(namespace, name string) string {
 	// A RoleRequest contains the Namespace/Name of the ServiceAccount in the management
 	// cluster for which a RoleRequest was issued (request to grant permission in managed clusters).
 	// When processing a RoleRequest, Sveltos creates a ServiceAccount in the managed cluster.
-	// Such ServiceAccount is created in the "projectsveltos" namespace.
+	// Such ServiceAccount is created in the namespace.
 	// This method returns the name of the ServiceAccount in the managed cluster (name cannot
 	// match the one in the management cluster to avoid clashes)
 	return fmt.Sprintf("%s--%s", namespace, name)

--- a/lib/sharding/utils.go
+++ b/lib/sharding/utils.go
@@ -76,9 +76,9 @@ func IsShardAMatch(shardKey string, cluster client.Object) bool {
 // returns a bool indicating whether the cluster:shard pair has changed and an error
 // if any occurred
 func RegisterClusterShard(ctx context.Context, c client.Client, component libsveltosv1beta1.Component,
-	feature, shard, clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) (bool, error) {
+	sveltosNamespace, feature, shard, clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) (bool, error) {
 
-	cm, err := getConfigMap(ctx, c, component, feature)
+	cm, err := getConfigMap(ctx, c, component, sveltosNamespace, feature)
 	if err != nil {
 		return false, err
 	}
@@ -109,9 +109,9 @@ func RegisterClusterShard(ctx context.Context, c client.Client, component libsve
 // UnregisterClusterShard removes the cluster entry from the shard-tracking ConfigMap.
 // Call this when a cluster is fully deleted so stale entries do not accumulate.
 func UnregisterClusterShard(ctx context.Context, c client.Client, component libsveltosv1beta1.Component,
-	feature, clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) error {
+	sveltosNamespace, feature, clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) error {
 
-	cm, err := getConfigMap(ctx, c, component, feature)
+	cm, err := getConfigMap(ctx, c, component, sveltosNamespace, feature)
 	if err != nil {
 		return err
 	}
@@ -130,8 +130,7 @@ func UnregisterClusterShard(ctx context.Context, c client.Client, component libs
 }
 
 const (
-	configMapName      = "clustersharding"
-	configMapNamespace = "projectsveltos"
+	configMapName = "clustersharding"
 )
 
 func getConfigMapName(component libsveltosv1beta1.Component, feature string) string {
@@ -141,15 +140,15 @@ func getConfigMapName(component libsveltosv1beta1.Component, feature string) str
 }
 
 func getConfigMap(ctx context.Context, c client.Client, component libsveltosv1beta1.Component,
-	feature string) (*corev1.ConfigMap, error) {
+	sveltosNamespace, feature string) (*corev1.ConfigMap, error) {
 
 	cm := &corev1.ConfigMap{}
 	name := getConfigMapName(component, feature)
 
-	err := c.Get(ctx, types.NamespacedName{Namespace: configMapNamespace, Name: name}, cm)
+	err := c.Get(ctx, types.NamespacedName{Namespace: sveltosNamespace, Name: name}, cm)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return createConfigMap(ctx, c, component, feature)
+			return createConfigMap(ctx, c, component, sveltosNamespace, feature)
 		}
 	}
 
@@ -157,12 +156,12 @@ func getConfigMap(ctx context.Context, c client.Client, component libsveltosv1be
 }
 
 func createConfigMap(ctx context.Context, c client.Client, component libsveltosv1beta1.Component,
-	feature string) (*corev1.ConfigMap, error) {
+	sveltosNamespace, feature string) (*corev1.ConfigMap, error) {
 
 	name := getConfigMapName(component, feature)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: configMapNamespace,
+			Namespace: sveltosNamespace,
 			Name:      name,
 		},
 	}

--- a/lib/sharding/utils_test.go
+++ b/lib/sharding/utils_test.go
@@ -26,44 +26,45 @@ var _ = Describe("Sharding", func() {
 		}
 
 		shard := randomString()
+		sveltosNamespace := randomString()
 		// First time, add entry and return false since cluster:shard was never changed
 		shardChanged, err := sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", shard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
+			sveltosNamespace, "helm", shard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeFalse())
 
 		// return false since cluster:shard was never changed
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", shard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
+			sveltosNamespace, "helm", shard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeFalse())
 
 		// return true since cluster:shard has changed
 		newShard := randomString()
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
+			sveltosNamespace, "helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeTrue())
 
 		// return false since cluster:shard has not changed (and previous step updated configMap)
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
+			sveltosNamespace, "helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeFalse())
 
 		// register capi cluster with same namespace/name of sveltoscluster used so far
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
+			sveltosNamespace, "helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeFalse())
 
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
+			sveltosNamespace, "helm", newShard, cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeFalse())
 
 		shardChanged, err = sharding.RegisterClusterShard(context.TODO(), c, libsveltosv1beta1.ComponentAddonManager,
-			"helm", randomString(), cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
+			sveltosNamespace, "helm", randomString(), cluster.Namespace, cluster.Name, libsveltosv1beta1.ClusterTypeCapi)
 		Expect(err).To(BeNil())
 		Expect(shardChanged).To(BeTrue())
 	})

--- a/lib/sveltos_upgrade/export_test.go
+++ b/lib/sveltos_upgrade/export_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sveltos_upgrade
 
 const (
-	ConfigMapNamespace          = configMapNamespace
 	SveltosAgentConfigMapName   = sveltosAgentConfigMapName
 	DriftDetectionConfigMapName = driftDetectionConfigMapName
 	ConfigMapKey                = configMapKey

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade.go
@@ -62,7 +62,6 @@ const (
 )
 
 const (
-	configMapNamespace          = "projectsveltos"
 	sveltosAgentConfigMapName   = "sveltos-agent-version"
 	driftDetectionConfigMapName = "drift-detection-version"
 	configMapKey                = "version"
@@ -81,10 +80,11 @@ const (
 //   - version (string): Version to compare against the sveltos-agent version
 //   - isAgentInMgmtMode indicates whether agents are in the management cluster (true) or managed clusters (false)
 
-func IsSveltosAgentVersionCompatible(ctx context.Context, c client.Client, version, clusterNamespace, clusterName string,
+func IsSveltosAgentVersionCompatible(ctx context.Context, c client.Client,
+	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) bool {
 
-	cmInfo := getSveltosAgentConfigMapInfo(clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	cmInfo := getSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
 
 	// ConfigMap is stored in either the management cluster or the managed cluster.
 	// If agents are in the management cluster, the ConfigMap is in the management cluster.
@@ -129,10 +129,11 @@ func IsSveltosAgentVersionCompatible(ctx context.Context, c client.Client, versi
 //   - version (string): Version to compare against the sveltos-agent version
 //   - isAgentInMgmtMode indicates whether agents are in the management cluster (true) or managed clusters (false)
 
-func IsDriftDetectionVersionCompatible(ctx context.Context, c client.Client, version, clusterNamespace, clusterName string,
+func IsDriftDetectionVersionCompatible(ctx context.Context, c client.Client,
+	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) bool {
 
-	cmInfo := getDriftDetectionConfigMapInfo(clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	cmInfo := getDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
 
 	// ConfigMap is stored in either the management cluster or the managed cluster.
 	// If agents are in the management cluster, the ConfigMap is in the management cluster.
@@ -174,13 +175,14 @@ func IsDriftDetectionVersionCompatible(ctx context.Context, c client.Client, ver
 //   - clusterNamespace, clusterName, clusterType identify the managed cluster
 //   - version (string): Version to compare against the sveltos-agent version
 //   - isAgentInMgmtMode indicates whether agents are in the management cluster (true) or managed clusters (false)
-func StoreSveltosAgentVersion(ctx context.Context, c client.Client, version, clusterNamespace, clusterName string,
+func StoreSveltosAgentVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
 
 	lbls := getLabels(clusterName, clusterType)
 	lbls[agentTypeLabel] = sveltosAgentType
 
-	cmInfo := getSveltosAgentConfigMapInfo(clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	cmInfo := getSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
 	cm, err := getConfigMap(ctx, c, cmInfo, logger)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -204,13 +206,14 @@ func StoreSveltosAgentVersion(ctx context.Context, c client.Client, version, clu
 //   - clusterNamespace, clusterName, clusterType identify the managed cluster
 //   - version (string): Version to compare against the sveltos-agent version
 //   - isAgentInMgmtMode indicates whether agents are in the management cluster (true) or managed clusters (false)
-func StoreDriftDetectionVersion(ctx context.Context, c client.Client, version, clusterNamespace, clusterName string,
+func StoreDriftDetectionVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
 
 	lbls := getLabels(clusterName, clusterType)
 	lbls[agentTypeLabel] = driftDetectionType
 
-	cmInfo := getDriftDetectionConfigMapInfo(clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	cmInfo := getDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
 	cm, err := getConfigMap(ctx, c, cmInfo, logger)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -278,8 +281,8 @@ func generateName(agentType, clusterName string, clusterTpe libsveltosv1beta1.Cl
 	return fmt.Sprintf("dd-%s-%s", strings.ToLower(string(clusterTpe)), clusterName)
 }
 
-func getSveltosAgentConfigMapInfo(clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
-	isAgentInMgmtMode bool) types.NamespacedName {
+func getSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool) types.NamespacedName {
 
 	var namespace, name string
 	if isAgentInMgmtMode {
@@ -287,14 +290,14 @@ func getSveltosAgentConfigMapInfo(clusterNamespace, clusterName string, clusterT
 		namespace = clusterNamespace
 	} else {
 		name = sveltosAgentConfigMapName
-		namespace = configMapNamespace
+		namespace = sveltosNamespace
 	}
 
 	return types.NamespacedName{Namespace: namespace, Name: name}
 }
 
-func getDriftDetectionConfigMapInfo(clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
-	isAgentInMgmtMode bool) types.NamespacedName {
+func getDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool) types.NamespacedName {
 
 	var namespace, name string
 	if isAgentInMgmtMode {
@@ -302,7 +305,7 @@ func getDriftDetectionConfigMapInfo(clusterNamespace, clusterName string, cluste
 		namespace = clusterNamespace
 	} else {
 		name = driftDetectionConfigMapName
-		namespace = configMapNamespace
+		namespace = sveltosNamespace
 	}
 
 	return types.NamespacedName{Namespace: namespace, Name: name}

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
@@ -40,9 +40,11 @@ const (
 
 var _ = Describe("SveltosAgent compatibility checks", func() {
 	var logger logr.Logger
+	var sveltosNamespace string
 
 	BeforeEach(func() {
 		logger = textlogger.NewLogger(textlogger.NewConfig())
+		sveltosNamespace = randomString()
 	})
 
 	It("Create ConfigMap with Sveltos-agent version", func() {
@@ -52,18 +54,18 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeSveltos
 
-		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, version, clusterNamespace,
-			clusterName, clusterType, false, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, false, logger)).To(Succeed())
 
 		cm := &corev1.ConfigMap{}
 		Expect(c.Get(context.TODO(),
-			types.NamespacedName{Namespace: sveltos_upgrade.ConfigMapNamespace, Name: sveltos_upgrade.SveltosAgentConfigMapName},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: sveltos_upgrade.SveltosAgentConfigMapName},
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
 
-		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, version, clusterNamespace,
-			clusterName, clusterType, true, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
 		name := sveltos_upgrade.GenerateName(sveltos_upgrade.SveltosAgentType, clusterName, clusterType)
 		Expect(c.Get(context.TODO(),
@@ -75,7 +77,7 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 	It("Update ConfigMap with Sveltos-agent version", func() {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sveltos_upgrade.ConfigMapNamespace,
+				Namespace: sveltosNamespace,
 				Name:      sveltos_upgrade.SveltosAgentConfigMapName,
 			},
 			Data: map[string]string{
@@ -88,19 +90,19 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeSveltos
 
-		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, false, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, false, logger)).To(Succeed())
 
 		Expect(c.Get(context.TODO(),
 			types.NamespacedName{
-				Namespace: sveltos_upgrade.ConfigMapNamespace,
+				Namespace: sveltosNamespace,
 				Name:      sveltos_upgrade.SveltosAgentConfigMapName},
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
 
-		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, true, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 		name := sveltos_upgrade.GenerateName(sveltos_upgrade.SveltosAgentType, clusterName, clusterType)
 
 		Expect(c.Get(context.TODO(),
@@ -117,7 +119,7 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeCapi
 
-		cmInfo := sveltos_upgrade.GetSveltosAgentConfigMapInfo(clusterNamespace, clusterName, clusterType, true)
+		cmInfo := sveltos_upgrade.GetSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, true)
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -134,18 +136,20 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
-		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, true, logger)).To(BeTrue())
-		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, randomString(), clusterNamespace, clusterName,
-			clusterType, true, logger)).To(BeFalse())
+		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(BeTrue())
+		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, sveltosNamespace, randomString(),
+			clusterNamespace, clusterName, clusterType, true, logger)).To(BeFalse())
 	})
 })
 
 var _ = Describe("DriftDetection compatibility checks", func() {
 	var logger logr.Logger
+	var sveltosNamespace string
 
 	BeforeEach(func() {
 		logger = textlogger.NewLogger(textlogger.NewConfig())
+		sveltosNamespace = randomString()
 	})
 
 	It("IsDriftDetectionVersionCompatible returns true when drift-detection version is compatible (agent in management cluster)", func() {
@@ -153,7 +157,7 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeSveltos
 
-		cmInfo := sveltos_upgrade.GetDriftDetectionConfigMapInfo(clusterNamespace, clusterName, clusterType, true)
+		cmInfo := sveltos_upgrade.GetDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, true)
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -170,21 +174,21 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
-		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, true, logger)).To(BeTrue())
-		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, randomString(), randomString(), randomString(),
-			clusterType, true, logger)).To(BeFalse())
+		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(BeTrue())
+		Expect(sveltos_upgrade.IsDriftDetectionVersionCompatible(context.TODO(), c, sveltosNamespace, randomString(),
+			randomString(), randomString(), clusterType, true, logger)).To(BeFalse())
 	})
 
 	It("Create ConfigMap with drift-detection-manager version", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, version, randomString(), randomString(),
-			libsveltosv1beta1.ClusterTypeCapi, false, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, false, logger)).To(Succeed())
 
 		cm := &corev1.ConfigMap{}
 		Expect(c.Get(context.TODO(),
-			types.NamespacedName{Namespace: sveltos_upgrade.ConfigMapNamespace, Name: sveltos_upgrade.DriftDetectionConfigMapName},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: sveltos_upgrade.DriftDetectionConfigMapName},
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
@@ -193,8 +197,8 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeCapi
 
-		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, true, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
 		name := sveltos_upgrade.GenerateName(sveltos_upgrade.DriftDetectionType, clusterName, clusterType)
 		Expect(c.Get(context.TODO(),
@@ -206,7 +210,7 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 	It("Update ConfigMap with drift-detection-manager version", func() {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sveltos_upgrade.ConfigMapNamespace,
+				Namespace: sveltosNamespace,
 				Name:      sveltos_upgrade.DriftDetectionConfigMapName,
 			},
 			Data: map[string]string{
@@ -215,12 +219,12 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		}
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, version, randomString(), randomString(),
-			libsveltosv1beta1.ClusterTypeCapi, false, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, false, logger)).To(Succeed())
 
 		Expect(c.Get(context.TODO(),
 			types.NamespacedName{
-				Namespace: sveltos_upgrade.ConfigMapNamespace,
+				Namespace: sveltosNamespace,
 				Name:      sveltos_upgrade.DriftDetectionConfigMapName},
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
@@ -230,8 +234,8 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeSveltos
 
-		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, version, clusterNamespace, clusterName,
-			clusterType, true, logger)).To(Succeed())
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
 		name := sveltos_upgrade.GenerateName(sveltos_upgrade.DriftDetectionType, clusterName, clusterType)
 		Expect(c.Get(context.TODO(),


### PR DESCRIPTION
Historically, the Sveltos namespace has been hardcoded/fixed to `projectsveltos`.
This PR is part of series that will remove this limitation.