### PR TITLE
Add lib/clustercache package, moved from addon-controller

### DIFF
--- a/lib/clustercache/cluster_cache.go
+++ b/lib/clustercache/cluster_cache.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/klog/v2/textlogger"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
+)
+
+var (
+	managerInstance *clusterCache
+	lock            = &sync.Mutex{}
+)
+
+type clusterCache struct {
+	rwMux sync.RWMutex
+	// Keeps cache of rest.Config for existing clusters
+	configs map[corev1.ObjectReference]*rest.Config
+
+	mappers               map[corev1.ObjectReference]*restmapper.DeferredDiscoveryRESTMapper
+	cachedDiscoveryClient map[corev1.ObjectReference]discovery.CachedDiscoveryInterface
+
+	// key: cluster, value: Secret with kubeconfig
+	clusters map[corev1.ObjectReference]*corev1.ObjectReference
+
+	// key: secret, value: set of clusters
+	// A secret can potentially contain kubeconfig for one or more clusters
+	secrets map[corev1.ObjectReference]*libsveltosset.Set
+}
+
+// GetManager return manager instance
+func GetManager() *clusterCache {
+	if managerInstance == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		if managerInstance == nil {
+			managerInstance = &clusterCache{
+				configs:               make(map[corev1.ObjectReference]*rest.Config),
+				clusters:              make(map[corev1.ObjectReference]*corev1.ObjectReference),
+				mappers:               make(map[corev1.ObjectReference]*restmapper.DeferredDiscoveryRESTMapper),
+				cachedDiscoveryClient: make(map[corev1.ObjectReference]discovery.CachedDiscoveryInterface),
+				secrets:               make(map[corev1.ObjectReference]*libsveltosset.Set),
+				rwMux:                 sync.RWMutex{},
+			}
+		}
+	}
+
+	return managerInstance
+}
+
+// RemoveCluster removes restConfig cached data for the cluster
+func (m *clusterCache) RemoveCluster(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	m.rwMux.Lock()
+	defer m.rwMux.Unlock()
+
+	// Remove from cache the restConfig for this cluster
+	delete(m.configs, *cluster)
+
+	if sec, ok := m.clusters[*cluster]; ok {
+		m.updateSecretMap(sec, cluster)
+	}
+
+	// Do not track this cluster anymore
+	delete(m.clusters, *cluster)
+
+	delete(m.mappers, *cluster)
+	delete(m.cachedDiscoveryClient, *cluster)
+}
+
+// RemoveSecret removes any in-memory data related to secret
+func (m *clusterCache) RemoveSecret(sec *corev1.ObjectReference) {
+	m.rwMux.Lock()
+	defer m.rwMux.Unlock()
+
+	v, ok := m.secrets[*sec]
+	if !ok {
+		return
+	}
+
+	clusters := v.Items()
+	for i := range clusters {
+		delete(m.configs, clusters[i])
+		delete(m.clusters, clusters[i])
+		delete(m.cachedDiscoveryClient, clusters[i])
+		delete(m.mappers, clusters[i])
+	}
+}
+
+// InvalidateOnAuthError evicts all cached data (rest.Config, mapper, discovery client) for
+// a cluster, plus the underlying workload-identity cache entry, if err indicates the API
+// server rejected the current credentials (401/403). Returns true if anything was evicted.
+func (m *clusterCache) InvalidateOnAuthError(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, err error) bool {
+
+	if err == nil || (!apierrors.IsUnauthorized(err) && !apierrors.IsForbidden(err)) {
+		return false
+	}
+
+	m.RemoveCluster(clusterNamespace, clusterName, clusterType)
+	clusterproxy.EvictWorkloadIdentityCache(clusterNamespace, clusterName)
+	return true
+}
+
+// GetKubernetesRestConfig returns managed cluster restConfig.
+// If result is cached, it will be returned immediately. Otherwise it will be built
+// by fetching the Secret containing the cluster kubeconfig.
+// Admins restConfig are never cached.
+func (m *clusterCache) GetKubernetesRestConfig(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName, adminNamespace, adminName string,
+	clusterType libsveltosv1beta1.ClusterType, logger logr.Logger) (*rest.Config, error) {
+
+	if adminNamespace != "" || adminName != "" {
+		// cluster configs for admins are not cached
+		return clusterproxy.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+			adminNamespace, adminName, clusterType, logger)
+	}
+
+	m.rwMux.Lock()
+	defer m.rwMux.Unlock()
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	config, ok := m.configs[*cluster]
+	if ok {
+		if config != nil {
+			logger.V(logs.LogInfo).Info("remote restConfig cache hit")
+		} else {
+			logger.V(logs.LogInfo).Info("remote restConfig cache hit: cluster in pull mode")
+		}
+		return config, nil
+	}
+
+	logger.V(logs.LogDebug).Info("remote restConfig cache miss")
+	remoteRestConfig, err := clusterproxy.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		adminNamespace, adminName, clusterType, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	var cachedDiscoveryClient discovery.CachedDiscoveryInterface
+	var mapper *restmapper.DeferredDiscoveryRESTMapper
+	if remoteRestConfig != nil {
+		dc, err := discovery.NewDiscoveryClientForConfig(remoteRestConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		cachedDiscoveryClient = memory.NewMemCacheClient(dc)
+		mapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	}
+
+	secretInfo, err := getSecretObjectReference(ctx, mgmtClient, clusterNamespace, clusterName, clusterType)
+	if err == nil {
+		// Either all internal structures are updated or none is
+		m.configs[*cluster] = remoteRestConfig
+		m.clusters[*cluster] = secretInfo
+		m.cachedDiscoveryClient[*cluster] = cachedDiscoveryClient
+		m.mappers[*cluster] = mapper
+		v, ok := m.secrets[*secretInfo]
+		if !ok {
+			v = &libsveltosset.Set{}
+		}
+		v.Insert(cluster)
+		m.secrets[*secretInfo] = v
+	}
+
+	return remoteRestConfig, nil
+}
+
+func (m *clusterCache) GetMapper(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) (*restmapper.DeferredDiscoveryRESTMapper, error) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	// 1. Use a Read Lock to check if it's already cached
+	m.rwMux.RLock()
+	mapper, ok := m.mappers[*cluster]
+	m.rwMux.RUnlock()
+
+	if ok {
+		return mapper, nil
+	}
+
+	// 2. Cache Miss: We need to initialize the config and mapper.
+	// Calling GetKubernetesRestConfig will populate m.mappers via the logic you wrote.
+	logger.V(logs.LogInfo).Info("mapper cache miss, initializing cluster config")
+	_, err := m.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		"", "", clusterType, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cluster config for mapper: %w", err)
+	}
+
+	// 3. Lock again to retrieve the newly created mapper
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	if v, ok := m.mappers[*cluster]; ok {
+		return v, nil
+	}
+
+	return nil, fmt.Errorf("mapper not found for cluster %s/%s after initialization", clusterNamespace, clusterName)
+}
+
+func (m *clusterCache) GetCachedDiscoveryClient(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) (discovery.CachedDiscoveryInterface, error) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	// 1. Thread-safe check for existing cached client
+	m.rwMux.RLock()
+	dc, ok := m.cachedDiscoveryClient[*cluster]
+	m.rwMux.RUnlock()
+
+	if ok {
+		return dc, nil
+	}
+
+	// 2. Cache Miss: Initialize the cluster configuration
+	// This will populate m.cachedDiscoveryClient via GetKubernetesRestConfig
+	logger.V(logs.LogInfo).Info("discovery client cache miss, initializing cluster config")
+	_, err := m.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		"", "", clusterType, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cluster config for discovery client: %w", err)
+	}
+
+	// 3. Retrieve the newly created client
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	if dc, ok := m.cachedDiscoveryClient[*cluster]; ok {
+		return dc, nil
+	}
+
+	return nil, fmt.Errorf("cached discovery client not found for cluster %s/%s after initialization",
+		clusterNamespace, clusterName)
+}
+
+func (m *clusterCache) ResetMapper(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) {
+
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+	if mapper, ok := m.mappers[*cluster]; ok {
+		mapper.Reset()
+	}
+}
+
+func (m *clusterCache) InvalidateDiscoveryClient(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) {
+
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+	if dc, ok := m.cachedDiscoveryClient[*cluster]; ok {
+		dc.Invalidate()
+	}
+}
+
+func (m *clusterCache) GetKubernetesClient(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName, adminNamespace, adminName string,
+	clusterType libsveltosv1beta1.ClusterType, logger logr.Logger) (client.Client, error) {
+
+	if adminNamespace != "" || adminName != "" {
+		// cluster configs for admins are not cached
+		return clusterproxy.GetKubernetesClient(ctx, mgmtClient, clusterNamespace, clusterName,
+			adminNamespace, adminName, clusterType, logger)
+	}
+
+	config, err := m.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		adminNamespace, adminName, clusterType, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.V(logs.LogVerbose).Info("return new client")
+	return client.New(config, client.Options{Scheme: mgmtClient.Scheme()})
+}
+
+func (m *clusterCache) StoreRestConfig(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, config *rest.Config) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	m.rwMux.Lock()
+	defer m.rwMux.Unlock()
+
+	m.configs[*cluster] = config
+}
+
+func (m *clusterCache) updateSecretMap(sec, cluster *corev1.ObjectReference) {
+	set, ok := m.secrets[*sec]
+	if ok {
+		set.Erase(cluster)
+		if set.Len() == 0 {
+			delete(m.secrets, *sec)
+		}
+	}
+}
+
+func getClusterObjectReference(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) *corev1.ObjectReference {
+
+	cluster := &corev1.ObjectReference{
+		Namespace:  clusterNamespace,
+		Name:       clusterName,
+		Kind:       clusterv1.ClusterKind,
+		APIVersion: clusterv1.GroupVersion.String(),
+	}
+	if clusterType == libsveltosv1beta1.ClusterTypeSveltos {
+		cluster.Kind = libsveltosv1beta1.SveltosClusterKind
+		cluster.APIVersion = libsveltosv1beta1.GroupVersion.String()
+	}
+
+	return cluster
+}
+
+func getSecretObjectReference(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) (*corev1.ObjectReference, error) {
+
+	secretKind := "Secret"
+	if clusterType == libsveltosv1beta1.ClusterTypeCapi {
+		return &corev1.ObjectReference{
+			Namespace:  clusterNamespace,
+			Name:       getClusterAPISecretName(clusterName),
+			Kind:       secretKind,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		}, nil
+	}
+
+	logger := textlogger.NewLogger(textlogger.NewConfig())
+	secretName, _, err := clusterproxy.GetSveltosSecretNameAndKey(ctx, logger, mgmtClient, clusterNamespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.ObjectReference{
+		Namespace:  clusterNamespace,
+		Name:       secretName,
+		Kind:       secretKind,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}, nil
+}
+
+func getClusterAPISecretName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, secret.Kubeconfig)
+}

--- a/lib/clustercache/cluster_cache_test.go
+++ b/lib/clustercache/cluster_cache_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercache_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
+)
+
+const (
+	sveltosKubeconfigPostfix = "-sveltos-kubeconfig"
+)
+
+var _ = Describe("Clustercache", func() {
+	var logger logr.Logger
+	var cluster *libsveltosv1beta1.SveltosCluster
+
+	BeforeEach(func() {
+		logger = textlogger.NewLogger(textlogger.NewConfig())
+		cluster = &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cache" + randomString(),
+				Namespace: "cache" + randomString(),
+			},
+		}
+	})
+
+	It("GetKubernetesRestConfig stores in memory first time. RemoveCluster removes any entry associated to cluster",
+		func() {
+			secret := createClusterResources(cluster)
+
+			cacheMgr := clustercache.GetManager()
+			_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+				cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+			Expect(err).To(BeNil())
+
+			clusterObj := &corev1.ObjectReference{
+				Namespace:  cluster.Namespace,
+				Name:       cluster.Name,
+				Kind:       libsveltosv1beta1.SveltosClusterKind,
+				APIVersion: libsveltosv1beta1.GroupVersion.String(),
+			}
+			Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+
+			storedSecret := cacheMgr.GetSecretForCluster(clusterObj)
+			Expect(storedSecret).ToNot(BeNil())
+			Expect(storedSecret.Namespace).To(Equal(secret.Namespace))
+			Expect(storedSecret.Name).To(Equal(secret.Name))
+
+			secretObj := &corev1.ObjectReference{
+				Namespace:  secret.Namespace,
+				Name:       secret.Name,
+				Kind:       testKindSecret,
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			}
+			storedCluster := cacheMgr.GetClusterFromSecret(secretObj)
+			Expect(storedCluster).ToNot(BeNil())
+			Expect(storedCluster.Namespace).To(Equal(cluster.Namespace))
+			Expect(storedCluster.Name).To(Equal(cluster.Name))
+
+			cacheMgr.RemoveCluster(cluster.Namespace, clusterObj.Name, libsveltosv1beta1.ClusterTypeSveltos)
+			Expect(cacheMgr.GetConfigFromMap(clusterObj)).To(BeNil())
+			Expect(cacheMgr.GetSecretForCluster(clusterObj)).To(BeNil())
+			Expect(cacheMgr.GetClusterFromSecret(secretObj)).To(BeNil())
+		})
+
+	It("RemoveSecret removes entries for all clusters using the modified secret", func() {
+		secret := createClusterResources(cluster)
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+			cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+		Expect(err).To(BeNil())
+
+		clusterObj := &corev1.ObjectReference{
+			Namespace:  cluster.Namespace,
+			Name:       cluster.Name,
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+
+		secretObj := &corev1.ObjectReference{
+			Namespace:  secret.Namespace,
+			Name:       secret.Name,
+			Kind:       testKindSecret,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		}
+		cacheMgr.RemoveSecret(secretObj)
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).To(BeNil())
+	})
+
+	It("InvalidateOnAuthError is a no-op and returns false when err is nil", func() {
+		createClusterResources(cluster)
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+			cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+		Expect(err).To(BeNil())
+
+		clusterObj := &corev1.ObjectReference{
+			Namespace:  cluster.Namespace,
+			Name:       cluster.Name,
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+
+		Expect(cacheMgr.InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			libsveltosv1beta1.ClusterTypeSveltos, nil)).To(BeFalse())
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+	})
+
+	It("InvalidateOnAuthError is a no-op and returns false for errors that are not Unauthorized/Forbidden", func() {
+		createClusterResources(cluster)
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+			cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+		Expect(err).To(BeNil())
+
+		clusterObj := &corev1.ObjectReference{
+			Namespace:  cluster.Namespace,
+			Name:       cluster.Name,
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+
+		notFoundErr := apierrors.NewNotFound(corev1.Resource("secrets"), "foo")
+		Expect(cacheMgr.InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			libsveltosv1beta1.ClusterTypeSveltos, notFoundErr)).To(BeFalse())
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+	})
+
+	It("InvalidateOnAuthError evicts the cache and returns true on Unauthorized", func() {
+		createClusterResources(cluster)
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+			cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+		Expect(err).To(BeNil())
+
+		clusterObj := &corev1.ObjectReference{
+			Namespace:  cluster.Namespace,
+			Name:       cluster.Name,
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+
+		unauthorizedErr := apierrors.NewUnauthorized("credentials rejected")
+		Expect(cacheMgr.InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			libsveltosv1beta1.ClusterTypeSveltos, unauthorizedErr)).To(BeTrue())
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).To(BeNil())
+	})
+
+	It("InvalidateOnAuthError evicts the cache and returns true on Forbidden", func() {
+		createClusterResources(cluster)
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv.Client, cluster.Namespace,
+			cluster.Name, "", "", libsveltosv1beta1.ClusterTypeSveltos, logger)
+		Expect(err).To(BeNil())
+
+		clusterObj := &corev1.ObjectReference{
+			Namespace:  cluster.Namespace,
+			Name:       cluster.Name,
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).ToNot(BeNil())
+
+		forbiddenErr := apierrors.NewForbidden(corev1.Resource("secrets"), "foo", nil)
+		Expect(cacheMgr.InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			libsveltosv1beta1.ClusterTypeSveltos, forbiddenErr)).To(BeTrue())
+		Expect(cacheMgr.GetConfigFromMap(clusterObj)).To(BeNil())
+	})
+})
+
+func createClusterResources(cluster *libsveltosv1beta1.SveltosCluster) *corev1.Secret {
+	By("Create the cluster's namespace")
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cluster.Namespace,
+		},
+	}
+
+	By("Create the secret with cluster kubeconfig")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name + sveltosKubeconfigPostfix,
+		},
+		Data: map[string][]byte{
+			"value": testEnv.Kubeconfig,
+		},
+	}
+
+	Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+	Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+	Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+	Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
+
+	Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+	Expect(waitForObject(context.TODO(), testEnv.Client, secret)).To(Succeed())
+	return secret
+}

--- a/lib/clustercache/clustercache_suite_test.go
+++ b/lib/clustercache/clustercache_suite_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercache_test
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/internal/test/helpers"
+)
+
+var (
+	testEnv *helpers.TestEnvironment
+	cancel  context.CancelFunc
+	ctx     context.Context
+	scheme  *runtime.Scheme
+)
+
+var (
+	cacheSyncBackoff = wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    8,
+		Jitter:   0.4,
+	}
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+
+	ctrl.SetLogger(klog.Background())
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	scheme, err = setupScheme()
+	Expect(err).To(BeNil())
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join("config", "crd", "bases"),
+	}, scheme)
+	testEnv, err = testEnvConfig.Build(scheme)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		By("Starting the manager")
+		err = testEnv.StartManager(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+
+	if synced := testEnv.GetCache().WaitForCacheSync(ctx); !synced {
+		time.Sleep(time.Second)
+	}
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func setupScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	if err := libsveltosv1beta1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func randomString() string {
+	const length = 10
+	return "a-" + util.RandomString(length)
+}
+
+// waitForObject waits for the cache to be updated helps in preventing test flakes due to the cache sync delays.
+func waitForObject(ctx context.Context, c client.Client, obj client.Object) error {
+	// Makes sure the cache is updated with the new object
+	objCopy := obj.DeepCopyObject().(client.Object)
+	key := client.ObjectKeyFromObject(obj)
+	if err := wait.ExponentialBackoff(
+		cacheSyncBackoff,
+		func() (done bool, err error) {
+			if err := c.Get(ctx, key, objCopy); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}); err != nil {
+		return fmt.Errorf("object %s, %s is not being added to the testenv client cache: %w",
+			obj.GetObjectKind().GroupVersionKind().String(), key, err)
+	}
+	return nil
+}

--- a/lib/clustercache/export_test.go
+++ b/lib/clustercache/export_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercache
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+func (m *clusterCache) GetConfigFromMap(cluster *corev1.ObjectReference) *rest.Config {
+	return m.configs[*cluster]
+}
+
+func (m *clusterCache) GetSecretForCluster(cluster *corev1.ObjectReference) *corev1.ObjectReference {
+	return m.clusters[*cluster]
+}
+
+func (m *clusterCache) GetClusterFromSecret(secret *corev1.ObjectReference) *corev1.ObjectReference {
+	set := m.secrets[*secret]
+	if set == nil {
+		return nil
+	}
+
+	if set.Len() == 0 {
+		return nil
+	}
+
+	items := set.Items()
+	return &items[0]
+}

--- a/lib/clustercache/test_constants_test.go
+++ b/lib/clustercache/test_constants_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercache_test
+
+const (
+	testKindSecret = "Secret"
+)


### PR DESCRIPTION
Moves the cluster rest.Config/mapper/discovery-client cache from addon-controller/controllers/clustercache into libsveltos as lib/clustercache, so it can be shared across addon-controller, event-manager, healthcheck-manager, and classifier.

Adds InvalidateOnAuthError, which evicts a cluster's cached rest.Config, mapper, and discovery client (plus the underlying workload-identity cache entry) when a call comes back Unauthorized/Forbidden, instead of only on TTL expiry or explicit delete.