### PR TITLE
feat: extract VerifyLicensePayload for signature-only verification

### DIFF
--- a/lib/licenses/license.go
+++ b/lib/licenses/license.go
@@ -42,6 +42,17 @@ const (
 	signatureKey = "licenseSignature"
 )
 
+const (
+	// LicensePayloadAnnotation is the annotation key under which a signed license's payload
+	// bytes (base64-encoded) can be relayed onto another object (e.g. SveltosCluster), for
+	// components that cannot reach the sveltos-license Secret directly.
+	LicensePayloadAnnotation = "license.projectsveltos.io/payload"
+
+	// LicenseSignatureAnnotation is the annotation key under which a signed license's
+	// signature bytes (base64-encoded) can be relayed alongside LicensePayloadAnnotation.
+	LicenseSignatureAnnotation = "license.projectsveltos.io/signature"
+)
+
 // Features is all features requiring a license
 // +kubebuilder:validation:Enum:=PullMode;MCP
 type Features string
@@ -139,6 +150,8 @@ func getActualGracePeriod(lp *LicensePayload) time.Duration {
 // LicenseVerificationResult encapsulates the outcome of the license verification.
 type LicenseVerificationResult struct {
 	Payload         *LicensePayload // The decoded license payload if found and unmarshaled
+	PayloadData     []byte          // The exact signed payload bytes, set once the signature has verified
+	SignatureData   []byte          // The signature bytes matching PayloadData
 	IsValid         bool            // True if license is fully valid
 	IsExpired       bool            // True if license is expired (either grace or enforced)
 	IsInGracePeriod bool            // True if license is expired but within grace period
@@ -197,40 +210,66 @@ func VerifyLicenseSecret(ctx context.Context, c client.Client, sveltosNamespace 
 		return result
 	}
 
+	result = VerifyLicensePayload(payloadData, signatureData, publicKey, logger)
+	if result.Payload == nil {
+		// Signature verification or unmarshaling failed. Reword the generic message to
+		// mention the secret this payload came from.
+		result.Message = fmt.Sprintf("%s (secret %s)", result.Message, secretNsName.String())
+		return result
+	}
+
+	verifyClusterFingerprint(ctx, c, result.Payload, &result, logger)
+	return result
+}
+
+// VerifyLicensePayload verifies a license's digital signature against publicKey and, if valid,
+// unmarshals and checks its expiration. Unlike VerifyLicenseSecret, it does not read a Secret
+// and does not check the cluster fingerprint (that check needs a client into the specific
+// cluster the license is meant for) — callers that need fingerprint validation should use
+// VerifyLicenseSecret, or call verifyClusterFingerprint-equivalent logic themselves.
+// This is meant for components that receive the payload/signature bytes relayed from
+// elsewhere (e.g. via LicensePayloadAnnotation/LicenseSignatureAnnotation) rather than
+// reading the sveltos-license Secret directly.
+func VerifyLicensePayload(payloadData, signatureData []byte, publicKey *rsa.PublicKey,
+	logger logr.Logger) LicenseVerificationResult {
+
+	result := LicenseVerificationResult{}
+
 	// Verify the digital signature
 	hashedPayload := sha256.Sum256(payloadData)
-	err = rsa.VerifyPSS(publicKey, crypto.SHA256, hashedPayload[:], signatureData, nil)
+	err := rsa.VerifyPSS(publicKey, crypto.SHA256, hashedPayload[:], signatureData, nil)
 	if err != nil {
 		result.IsExpired = true
 		result.IsEnforced = true
-		result.Message = fmt.Sprintf("Digital signature verification failed for license from secret %s: %v",
-			secretNsName.String(), err)
+		result.Message = fmt.Sprintf("Digital signature verification failed for license: %v", err)
 		result.RawError = err
 		logger.V(logs.LogInfo).Info(result.Message, "error", err)
 		return result
 	}
 
-	logger.V(logs.LogDebug).Info("Digital signature successfully verified for license from secret")
+	logger.V(logs.LogDebug).Info("Digital signature successfully verified for license")
+
+	result.PayloadData = payloadData
+	result.SignatureData = signatureData
 
 	// Unmarshal the LicensePayload from the verified data
 	var verifiedPayload LicensePayload
 	if err := json.Unmarshal(payloadData, &verifiedPayload); err != nil {
 		result.IsExpired = true
 		result.IsEnforced = true
-		result.Message = fmt.Sprintf("Failed to unmarshal verified license payload from secret %q: %v", secretNsName.String(), err)
+		result.Message = fmt.Sprintf("Failed to unmarshal verified license payload: %v", err)
 		result.RawError = err
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("%s: %v", err, result.Message))
 		return result
 	}
 	result.Payload = &verifiedPayload
 
-	result = verifyExpirationDate(&verifiedPayload, result, logger)
-
-	return verifyClusterFingerprint(ctx, c, &verifiedPayload, result, logger)
+	verifyExpirationDate(&verifiedPayload, &result, logger)
+	return result
 }
 
-func verifyExpirationDate(verifiedPayload *LicensePayload, result LicenseVerificationResult,
-	logger logr.Logger) LicenseVerificationResult {
+func verifyExpirationDate(verifiedPayload *LicensePayload, result *LicenseVerificationResult,
+	logger logr.Logger) {
 
 	// --- License Expiration and Grace Period Logic ---
 	now := time.Now()
@@ -263,12 +302,10 @@ func verifyExpirationDate(verifiedPayload *LicensePayload, result LicenseVerific
 			enforcementDate.Format(time.RFC3339))
 		logger.V(logs.LogInfo).Info(result.Message)
 	}
-
-	return result
 }
 
 func verifyClusterFingerprint(ctx context.Context, c client.Client, verifiedPayload *LicensePayload,
-	result LicenseVerificationResult, logger logr.Logger) LicenseVerificationResult {
+	result *LicenseVerificationResult, logger logr.Logger) {
 
 	// --- Cluster Fingerprint Validation ---
 	if result.IsValid && verifiedPayload.ClusterFingerprint != "" &&
@@ -287,8 +324,6 @@ func verifyClusterFingerprint(ctx context.Context, c client.Client, verifiedPayl
 		}
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("%s: %v", result.RawError, result.Message))
 	}
-
-	return result
 }
 
 func isClusterFingerprintValid(ctx context.Context, c client.Client, clusterFingerprint string,

--- a/lib/licenses/license_test.go
+++ b/lib/licenses/license_test.go
@@ -19,6 +19,7 @@ package license_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +39,12 @@ import (
 
 const (
 	kubeSystemNamespace = "kube-system"
+
+	// validLicenseDataB64 / validLicenseSignatureB64 are the licenseData/licenseSignature
+	// values of a valid, non-expired license (Enterprise plan, PullMode feature, MaxClusters 1).
+	// Shared by multiple tests below so this fixture isn't duplicated further.
+	validLicenseDataB64      = "eyJpZCI6IjdmNDU0Mjk4LWUyYjItNDFhOC05MWRjLTc4ZjU5MjE4Nzk5MiIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwicGxhbiI6IkVudGVycHJpc2UiLCJleHBpcmF0aW9uRGF0ZSI6IjIwMjctMDctMjZUMTM6NDc6MzEuODUyMjE2WiIsImdyYWNlUGVyaW9kRGF5cyI6NywibWF4Q2x1c3RlcnMiOjEsImlzc3VlZEF0IjoiMjAyNi0wNy0yNlQxMzo0NzozMS44NTIyMTZaIn0="
+	validLicenseSignatureB64 = "BjYc6SDAcfrj4rBc4Fi0LfcdkU5qtAEojunwFV/0Llpsgx+IYi+XDyiq6VhZFDGl24tMcKOSHyPoTA3/5s5IIeZVpDRSd2+BXXFd9ccBScfyKRzDlO8Cg5rs0ejNwzrJKTNPxjorB7WxB3WK7ad6hbrmU6/PI6vdER7XjPsb3BuaDpzA5Z3wiuoyzB+BFJ9fbeVSDL2XxaZ+M/ifaM8/bGKsj7dUXwrP+ArNouObikxBsJsqZ9n1mgQx6WZm8fJOxct79Qmva1ys4O8QcP4MYY6rsbfag0xshpKKaZKMO10XugqtDYWz14pDV9vMKWEM0jMa4oHZmebMd4Wq+F/tB+GVIyYU8aWroYVKU5kkWFdFOcQozdNmyyLOn1umdJd2JouEWkcDHIRKfA1TpIfwaeKHB6JjW5WpKzbFfnrZUW9LWVOSegmv/HpgvXMiAXUyvVlhPHArPjBJyKhb5FNcb2kaYAk8ouFv/ydhFFcerTJMWp7bqkeLWlgMfUtw/oC0GKBLM090ovCkYAeaxjgWqm9sHVJCTFGeeqh2hff98UfAoQ5g9R9mP8e1rXNtWtdWK2UIaxcwymTKS7RNe2K3TpVORE4ESuOpSJMjUut7w2oAo1O7C2ZAlfoTi4JQmqBU9S+XG4AoEBkFPPbIlA8ak0xZU9Hh3Ony7WGr59tmkOU="
 )
 
 var _ = Describe("License", func() {
@@ -88,9 +95,9 @@ metadata:
   namespace: %s
 type: Opaque
 data:
-  licenseData: eyJpZCI6IjdmNDU0Mjk4LWUyYjItNDFhOC05MWRjLTc4ZjU5MjE4Nzk5MiIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwicGxhbiI6IkVudGVycHJpc2UiLCJleHBpcmF0aW9uRGF0ZSI6IjIwMjctMDctMjZUMTM6NDc6MzEuODUyMjE2WiIsImdyYWNlUGVyaW9kRGF5cyI6NywibWF4Q2x1c3RlcnMiOjEsImlzc3VlZEF0IjoiMjAyNi0wNy0yNlQxMzo0NzozMS44NTIyMTZaIn0=
-  licenseSignature: BjYc6SDAcfrj4rBc4Fi0LfcdkU5qtAEojunwFV/0Llpsgx+IYi+XDyiq6VhZFDGl24tMcKOSHyPoTA3/5s5IIeZVpDRSd2+BXXFd9ccBScfyKRzDlO8Cg5rs0ejNwzrJKTNPxjorB7WxB3WK7ad6hbrmU6/PI6vdER7XjPsb3BuaDpzA5Z3wiuoyzB+BFJ9fbeVSDL2XxaZ+M/ifaM8/bGKsj7dUXwrP+ArNouObikxBsJsqZ9n1mgQx6WZm8fJOxct79Qmva1ys4O8QcP4MYY6rsbfag0xshpKKaZKMO10XugqtDYWz14pDV9vMKWEM0jMa4oHZmebMd4Wq+F/tB+GVIyYU8aWroYVKU5kkWFdFOcQozdNmyyLOn1umdJd2JouEWkcDHIRKfA1TpIfwaeKHB6JjW5WpKzbFfnrZUW9LWVOSegmv/HpgvXMiAXUyvVlhPHArPjBJyKhb5FNcb2kaYAk8ouFv/ydhFFcerTJMWp7bqkeLWlgMfUtw/oC0GKBLM090ovCkYAeaxjgWqm9sHVJCTFGeeqh2hff98UfAoQ5g9R9mP8e1rXNtWtdWK2UIaxcwymTKS7RNe2K3TpVORE4ESuOpSJMjUut7w2oAo1O7C2ZAlfoTi4JQmqBU9S+XG4AoEBkFPPbIlA8ak0xZU9Hh3Ony7WGr59tmkOU=`,
-			sveltosNamespace)
+  licenseData: %s
+  licenseSignature: %s`,
+			sveltosNamespace, validLicenseDataB64, validLicenseSignatureB64)
 
 		u, err := k8s_utils.GetUnstructured([]byte(secret))
 		Expect(err).To(BeNil())
@@ -165,6 +172,55 @@ data:
 		licenseVerificationResult = license.VerifyLicenseSecret(context.TODO(), c, sveltosNamespace, publicKey, logger)
 		Expect(licenseVerificationResult.RawError).ToNot(BeNil())
 		Expect(licenseVerificationResult.RawError.Error()).To(ContainSubstring("License is not valid for this cluster (fingerprint mismatch)"))
+	})
+})
+
+var _ = Describe("VerifyLicensePayload", func() {
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+	})
+
+	It("verifies a valid payload/signature pair without reading a Secret", func() {
+		payloadData, err := base64.StdEncoding.DecodeString(validLicenseDataB64)
+		Expect(err).To(BeNil())
+		signatureData, err := base64.StdEncoding.DecodeString(validLicenseSignatureB64)
+		Expect(err).To(BeNil())
+
+		publicKey, err := license.GetPublicKey()
+		Expect(err).To(BeNil())
+
+		result := license.VerifyLicensePayload(payloadData, signatureData, publicKey, logger)
+		Expect(result.RawError).To(BeNil())
+		Expect(result.IsExpired).To(BeFalse())
+		Expect(result.IsInGracePeriod).To(BeFalse())
+
+		Expect(result.Payload).ToNot(BeNil())
+		Expect(result.Payload.Features).To(ContainElements(license.FeaturePullMode))
+		Expect(result.Payload.MaxClusters).To(Equal(1))
+
+		Expect(result.PayloadData).To(Equal(payloadData))
+		Expect(result.SignatureData).To(Equal(signatureData))
+	})
+
+	It("rejects a payload that does not match the signature", func() {
+		payloadData, err := base64.StdEncoding.DecodeString(validLicenseDataB64)
+		Expect(err).To(BeNil())
+		signatureData, err := base64.StdEncoding.DecodeString(validLicenseSignatureB64)
+		Expect(err).To(BeNil())
+
+		// Tamper with the payload after it was signed.
+		payloadData = append(payloadData, []byte("tampered")...)
+
+		publicKey, err := license.GetPublicKey()
+		Expect(err).To(BeNil())
+
+		result := license.VerifyLicensePayload(payloadData, signatureData, publicKey, logger)
+		Expect(result.RawError).ToNot(BeNil())
+		Expect(result.Payload).To(BeNil())
+		Expect(result.IsExpired).To(BeTrue())
+		Expect(result.IsEnforced).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Add two new annotation-key constants, `LicensePayloadAnnotation` / `LicenseSignatureAnnotation`.