### PR TITLE
Allow per-resource Force override via projectsveltos.io/forceRecreate annotation

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -351,7 +351,7 @@ type JobHealthCheck struct {
 	JobRef PolicyRef `json:"jobRef"`
 
 	// Timeout is how long to wait for the Job to reach Complete or Failed
-	// before treating the check as failed.
+	// before treating the check as failed. Defaults to 5 minutes when unset.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -304,7 +304,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -517,7 +517,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -730,7 +730,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -1057,7 +1057,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -322,7 +322,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -535,7 +535,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -748,7 +748,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -1075,7 +1075,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef

--- a/lib/deployer/applier.go
+++ b/lib/deployer/applier.go
@@ -58,7 +58,27 @@ const (
 
 	recreateDeletePollInterval = 2 * time.Second
 	recreateDeletePollTimeout  = time.Minute
+
+	// When this annotation is set on a resource, that resource is force-recreated on a
+	// delete+recreate-only update error, regardless of the KustomizationRef/PolicyRef-level
+	// Force setting.
+	forceRecreateAnnotation = "projectsveltos.io/forceRecreate"
 )
+
+// HasForceRecreateAnnotation verifies whether resource has the
+// `projectsveltos.io/forceRecreate` annotation set. Any resource with this annotation is
+// force-recreated on a delete+recreate-only update error, regardless of the
+// KustomizationRef/PolicyRef-level Force setting.
+func HasForceRecreateAnnotation(resource *unstructured.Unstructured) bool {
+	annotations := resource.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[forceRecreateAnnotation]; ok {
+			return true
+		}
+	}
+
+	return false
+}
 
 // requiresRecreate returns true if err indicates the API server rejected the request
 // because of an invalid combination of fields (eg a Deployment with strategy.rollingUpdate
@@ -511,10 +531,11 @@ func removeDriftExclusionsFields(ctx context.Context, dr dynamic.ResourceInterfa
 
 // UpdateResource creates or updates a resource in a Cluster.
 // No action in DryRun mode.
-// When forceRecreate is true, and the apply is rejected with an error that only a
-// delete+recreate can resolve (see requiresRecreate), the object is deleted and recreated
-// instead of returning the error. This never applies to CustomResourceDefinitions, since
-// deleting one cascades to every instance of it.
+// When forceRecreate is true, or object carries the `projectsveltos.io/forceRecreate`
+// annotation (see HasForceRecreateAnnotation), and the apply is rejected with an error
+// that only a delete+recreate can resolve (see requiresRecreate), the object is deleted
+// and recreated instead of returning the error. This never applies to
+// CustomResourceDefinitions, since deleting one cascades to every instance of it.
 func UpdateResource(ctx context.Context, dr dynamic.ResourceInterface, isDriftDetection, isDryRun, forceRecreate bool,
 	driftExclusions []libsveltosv1beta1.DriftExclusion, object *unstructured.Unstructured, subresources []string,
 	logger logr.Logger) (*unstructured.Unstructured, error) {
@@ -576,7 +597,7 @@ func UpdateResource(ctx context.Context, dr dynamic.ResourceInterface, isDriftDe
 			return nil
 		})
 
-		if err != nil && !isDryRun && forceRecreate && requiresRecreate(err) {
+		if err != nil && !isDryRun && (forceRecreate || HasForceRecreateAnnotation(object)) && requiresRecreate(err) {
 			l.V(logs.LogInfo).Info(fmt.Sprintf("apply rejected (%v), recreating resource", err))
 			if recreateErr := recreateResource(ctx, dr, object); recreateErr != nil {
 				return nil, recreateErr

--- a/lib/deployer/applier_test.go
+++ b/lib/deployer/applier_test.go
@@ -385,6 +385,8 @@ data:
 	deploymentKind   = "Deployment"
 	appsGroup        = "apps"
 	v1Version        = "v1"
+
+	forceRecreateAnnotationKey = "projectsveltos.io/forceRecreate"
 )
 
 var _ = Describe("Applier utils", func() {
@@ -711,6 +713,25 @@ var _ = Describe("requiresRecreate", func() {
 	})
 })
 
+var _ = Describe("HasForceRecreateAnnotation", func() {
+	It("returns true when the projectsveltos.io/forceRecreate annotation is set", func() {
+		resource := &unstructured.Unstructured{}
+		resource.SetAnnotations(map[string]string{forceRecreateAnnotationKey: ""})
+		Expect(deployer.HasForceRecreateAnnotation(resource)).To(BeTrue())
+	})
+
+	It("returns false when the annotation is not set", func() {
+		resource := &unstructured.Unstructured{}
+		resource.SetAnnotations(map[string]string{"foo": "bar"})
+		Expect(deployer.HasForceRecreateAnnotation(resource)).To(BeFalse())
+	})
+
+	It("returns false when there are no annotations", func() {
+		resource := &unstructured.Unstructured{}
+		Expect(deployer.HasForceRecreateAnnotation(resource)).To(BeFalse())
+	})
+})
+
 var _ = Describe("GenerateErrorResourceReport", func() {
 	It("returns a ResourceReport with Error action and the error message", func() {
 		resource := &libsveltosv1beta1.Resource{
@@ -828,5 +849,51 @@ var _ = Describe("UpdateResource force recreate", func() {
 
 		_, found, _ := unstructured.NestedMap(updated.Object, "spec", "strategy", "rollingUpdate")
 		Expect(found).To(BeFalse())
+	})
+
+	It("recreates a Deployment when forceRecreate is false but the object carries the forceRecreate annotation", func() {
+		name := randomString()
+		nsName := randomString()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		logger := textlogger.NewLogger(textlogger.NewConfig())
+
+		initialYAML := fmt.Sprintf(deploymentNoStrategyTemplate, name, nsName, name, name)
+		initialObj, err := k8s_utils.GetUnstructured([]byte(initialYAML))
+		Expect(err).To(BeNil())
+
+		dr, err := k8s_utils.GetDynamicResourceInterface(testEnv.Config, initialObj.GroupVersionKind(), nsName)
+		Expect(err).To(BeNil())
+
+		_, err = deployer.UpdateResource(context.TODO(), dr, false, false, false,
+			nil, initialObj, nil, logger)
+		Expect(err).To(BeNil())
+
+		Eventually(func() bool {
+			current, getErr := dr.Get(context.TODO(), name, metav1.GetOptions{})
+			if getErr != nil {
+				return false
+			}
+			_, found, _ := unstructured.NestedMap(current.Object, "spec", "strategy", "rollingUpdate")
+			return found
+		}, time.Minute, 5*time.Second).Should(BeTrue())
+
+		recreateYAML := fmt.Sprintf(deploymentRecreateStrategyTemplate, name, nsName, name, name)
+		recreateObj, err := k8s_utils.GetUnstructured([]byte(recreateYAML))
+		Expect(err).To(BeNil())
+		recreateObj.SetAnnotations(map[string]string{forceRecreateAnnotationKey: ""})
+
+		// forceRecreate is false, but the resource-level annotation still triggers the
+		// delete+recreate path.
+		updated, err := deployer.UpdateResource(context.TODO(), dr, false, false, false,
+			nil, recreateObj, nil, logger)
+		Expect(err).To(BeNil())
+		Expect(updated).ToNot(BeNil())
+
+		strategyType, _, _ := unstructured.NestedString(updated.Object, "spec", "strategy", "type")
+		Expect(strategyType).To(Equal("Recreate"))
 	})
 })

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -303,7 +303,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -516,7 +516,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -729,7 +729,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef
@@ -1056,7 +1056,7 @@ spec:
                         timeout:
                           description: |-
                             Timeout is how long to wait for the Job to reach Complete or Failed
-                            before treating the check as failed.
+                            before treating the check as failed. Defaults to 5 minutes when unset.
                           type: string
                       required:
                       - jobRef


### PR DESCRIPTION
KustomizationRef.Force / PolicyRef.Force apply to every resource in the reference, all-or-nothing. This adds a per-resource option: a resource carrying the _projectsveltos.io/forceRecreate_ annotation is now force-recreated on a delete+recreate-only update error even when the reference-level Force is false