### PR TITLE
chore: Add Jobs used as health validatior

### DIFF
--- a/api/v1beta1/configurationgroup_type.go
+++ b/api/v1beta1/configurationgroup_type.go
@@ -175,6 +175,18 @@ type ConfigurationGroupSpec struct {
 	// +optional
 	PreDeployChecks []ValidateHealth `json:"preDeployChecks,omitempty"`
 
+	// PreDeployCheckJobs holds the resolved manifest for every PreDeployChecks entry that uses
+	// JobCheck, keyed by "<namespace>/<name>" (the namespace/name JobHealthCheck.JobRef
+	// resolves to). The value is the YAML-encoded Job manifest.
+	// JobCheck requires a Sveltos Enterprise license, which sveltos-applier (an open-source
+	// binary) cannot verify on its own, so addon-controller resolves each Job manifest once,
+	// up front - fetching JobRef's ConfigMap/Secret and applying Cluster-field templating -
+	// and stages the result here. Sveltos-applier only ever runs the already-resolved Job; it
+	// never fetches JobRef or checks licensing itself.
+	// Empty when no PreDeployChecks entry uses JobCheck.
+	// +optional
+	PreDeployCheckJobs map[string]string `json:"preDeployCheckJobs,omitempty"`
+
 	// ValidateHealths is a slice of checks to run against the managed cluster
 	// *after* resources are deployed to validate that the state of the
 	// add-ons/applications is healthy.
@@ -182,6 +194,12 @@ type ConfigurationGroupSpec struct {
 	// +listType=atomic
 	// +optional
 	ValidateHealths []ValidateHealth `json:"validateHealths,omitempty"`
+
+	// ValidateHealthJobs holds the resolved manifest for every ValidateHealths entry that uses
+	// JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+	// time by addon-controller rather than fetched by sveltos-applier.
+	// +optional
+	ValidateHealthJobs map[string]string `json:"validateHealthJobs,omitempty"`
 
 	// PreDeleteChecks is a slice of checks to run against the managed cluster
 	// *before* Sveltos starts deleting resources.
@@ -191,6 +209,12 @@ type ConfigurationGroupSpec struct {
 	// +optional
 	PreDeleteChecks []ValidateHealth `json:"preDeleteChecks,omitempty"`
 
+	// PreDeleteCheckJobs holds the resolved manifest for every PreDeleteChecks entry that uses
+	// JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+	// time by addon-controller rather than fetched by sveltos-applier.
+	// +optional
+	PreDeleteCheckJobs map[string]string `json:"preDeleteCheckJobs,omitempty"`
+
 	// PostDeleteChecks is a slice of checks to run against the managed cluster
 	// *after* Sveltos has deleted all resources.
 	// This ensures that the environment has reached the desired clean state.
@@ -198,6 +222,12 @@ type ConfigurationGroupSpec struct {
 	// +listType=atomic
 	// +optional
 	PostDeleteChecks []ValidateHealth `json:"postDeleteChecks,omitempty"`
+
+	// PostDeleteCheckJobs holds the resolved manifest for every PostDeleteChecks entry that
+	// uses JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead
+	// of time by addon-controller rather than fetched by sveltos-applier.
+	// +optional
+	PostDeleteCheckJobs map[string]string `json:"postDeleteCheckJobs,omitempty"`
 
 	// DeployedGroupVersionKind contains all GroupVersionKinds deployed in either
 	// the workload cluster or the management cluster because of this feature.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -921,11 +921,25 @@ func (in *ConfigurationGroupSpec) DeepCopyInto(out *ConfigurationGroupSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PreDeployCheckJobs != nil {
+		in, out := &in.PreDeployCheckJobs, &out.PreDeployCheckJobs
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ValidateHealths != nil {
 		in, out := &in.ValidateHealths, &out.ValidateHealths
 		*out = make([]ValidateHealth, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.ValidateHealthJobs != nil {
+		in, out := &in.ValidateHealthJobs, &out.ValidateHealthJobs
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.PreDeleteChecks != nil {
@@ -935,11 +949,25 @@ func (in *ConfigurationGroupSpec) DeepCopyInto(out *ConfigurationGroupSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PreDeleteCheckJobs != nil {
+		in, out := &in.PreDeleteCheckJobs, &out.PreDeleteCheckJobs
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PostDeleteChecks != nil {
 		in, out := &in.PostDeleteChecks, &out.PostDeleteChecks
 		*out = make([]ValidateHealth, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.PostDeleteCheckJobs != nil {
+		in, out := &in.PostDeleteCheckJobs, &out.PostDeleteCheckJobs
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.DeployedGroupVersionKind != nil {

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -215,6 +215,14 @@ spec:
                   This setting applies only to feature deployments, not resource removal.
                   This field is optional. If not set, Sveltos default behavior is to keep retrying.
                 type: integer
+              postDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PostDeleteCheckJobs holds the resolved manifest for every PostDeleteChecks entry that
+                  uses JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead
+                  of time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               postDeleteChecks:
                 description: |-
                   PostDeleteChecks is a slice of checks to run against the managed cluster
@@ -428,6 +436,14 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeleteCheckJobs holds the resolved manifest for every PreDeleteChecks entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               preDeleteChecks:
                 description: |-
                   PreDeleteChecks is a slice of checks to run against the managed cluster
@@ -641,6 +657,20 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeployCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeployCheckJobs holds the resolved manifest for every PreDeployChecks entry that uses
+                  JobCheck, keyed by "<namespace>/<name>" (the namespace/name JobHealthCheck.JobRef
+                  resolves to). The value is the YAML-encoded Job manifest.
+                  JobCheck requires a Sveltos Enterprise license, which sveltos-applier (an open-source
+                  binary) cannot verify on its own, so addon-controller resolves each Job manifest once,
+                  up front - fetching JobRef's ConfigMap/Secret and applying Cluster-field templating -
+                  and stages the result here. Sveltos-applier only ever runs the already-resolved Job; it
+                  never fetches JobRef or checks licensing itself.
+                  Empty when no PreDeployChecks entry uses JobCheck.
+                type: object
               preDeployChecks:
                 description: |-
                   PreDeployChecks is a slice of checks to run against the managed cluster
@@ -968,6 +998,14 @@ spec:
                 - Ready
                 - Preparing
                 type: string
+              validateHealthJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ValidateHealthJobs holds the resolved manifest for every ValidateHealths entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of checks to run against the managed cluster

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -233,6 +233,14 @@ spec:
                   This setting applies only to feature deployments, not resource removal.
                   This field is optional. If not set, Sveltos default behavior is to keep retrying.
                 type: integer
+              postDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PostDeleteCheckJobs holds the resolved manifest for every PostDeleteChecks entry that
+                  uses JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead
+                  of time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               postDeleteChecks:
                 description: |-
                   PostDeleteChecks is a slice of checks to run against the managed cluster
@@ -446,6 +454,14 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeleteCheckJobs holds the resolved manifest for every PreDeleteChecks entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               preDeleteChecks:
                 description: |-
                   PreDeleteChecks is a slice of checks to run against the managed cluster
@@ -659,6 +675,20 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeployCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeployCheckJobs holds the resolved manifest for every PreDeployChecks entry that uses
+                  JobCheck, keyed by "<namespace>/<name>" (the namespace/name JobHealthCheck.JobRef
+                  resolves to). The value is the YAML-encoded Job manifest.
+                  JobCheck requires a Sveltos Enterprise license, which sveltos-applier (an open-source
+                  binary) cannot verify on its own, so addon-controller resolves each Job manifest once,
+                  up front - fetching JobRef's ConfigMap/Secret and applying Cluster-field templating -
+                  and stages the result here. Sveltos-applier only ever runs the already-resolved Job; it
+                  never fetches JobRef or checks licensing itself.
+                  Empty when no PreDeployChecks entry uses JobCheck.
+                type: object
               preDeployChecks:
                 description: |-
                   PreDeployChecks is a slice of checks to run against the managed cluster
@@ -986,6 +1016,14 @@ spec:
                 - Ready
                 - Preparing
                 type: string
+              validateHealthJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ValidateHealthJobs holds the resolved manifest for every ValidateHealths entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of checks to run against the managed cluster

--- a/lib/pullmode/setters.go
+++ b/lib/pullmode/setters.go
@@ -37,9 +37,13 @@ type Options struct {
 	MaxConsecutiveFailures *uint
 	LeavePolicies          bool
 	PreDeployChecks        []libsveltosv1beta1.ValidateHealth
+	PreDeployCheckJobs     map[string]string
 	ValidateHealths        []libsveltosv1beta1.ValidateHealth
+	ValidateHealthJobs     map[string]string
 	PreDeleteChecks        []libsveltosv1beta1.ValidateHealth
+	PreDeleteCheckJobs     map[string]string
 	PostDeleteChecks       []libsveltosv1beta1.ValidateHealth
+	PostDeleteCheckJobs    map[string]string
 	DeployedGVKs           []string
 	Annotations            map[string]string
 	RequestorHash          []byte
@@ -84,9 +88,25 @@ func WithPreDeployChecks(preDeployChecks []libsveltosv1beta1.ValidateHealth) Opt
 	}
 }
 
+// WithPreDeployCheckJobs sets the resolved Job manifests (keyed by "<namespace>/<name>") for
+// any JobCheck entries in PreDeployChecks. See ConfigurationGroupSpec.PreDeployCheckJobs.
+func WithPreDeployCheckJobs(jobs map[string]string) Option {
+	return func(args *Options) {
+		args.PreDeployCheckJobs = jobs
+	}
+}
+
 func WithValidateHealths(validateHealths []libsveltosv1beta1.ValidateHealth) Option {
 	return func(args *Options) {
 		args.ValidateHealths = validateHealths
+	}
+}
+
+// WithValidateHealthJobs sets the resolved Job manifests (keyed by "<namespace>/<name>") for
+// any JobCheck entries in ValidateHealths. See ConfigurationGroupSpec.ValidateHealthJobs.
+func WithValidateHealthJobs(jobs map[string]string) Option {
+	return func(args *Options) {
+		args.ValidateHealthJobs = jobs
 	}
 }
 
@@ -96,9 +116,25 @@ func WithPreDeleteChecks(preDeleteChecks []libsveltosv1beta1.ValidateHealth) Opt
 	}
 }
 
+// WithPreDeleteCheckJobs sets the resolved Job manifests (keyed by "<namespace>/<name>") for
+// any JobCheck entries in PreDeleteChecks. See ConfigurationGroupSpec.PreDeleteCheckJobs.
+func WithPreDeleteCheckJobs(jobs map[string]string) Option {
+	return func(args *Options) {
+		args.PreDeleteCheckJobs = jobs
+	}
+}
+
 func WithPostDeleteChecks(postDeleteChecks []libsveltosv1beta1.ValidateHealth) Option {
 	return func(args *Options) {
 		args.PostDeleteChecks = postDeleteChecks
+	}
+}
+
+// WithPostDeleteCheckJobs sets the resolved Job manifests (keyed by "<namespace>/<name>") for
+// any JobCheck entries in PostDeleteChecks. See ConfigurationGroupSpec.PostDeleteCheckJobs.
+func WithPostDeleteCheckJobs(jobs map[string]string) Option {
+	return func(args *Options) {
+		args.PostDeleteCheckJobs = jobs
 	}
 }
 
@@ -181,9 +217,13 @@ func applySetters(confGroup *libsveltosv1beta1.ConfigurationGroup, setters ...Op
 	confGroup.Spec.DriftExclusions = c.DriftExclusion
 
 	confGroup.Spec.ValidateHealths = c.ValidateHealths
+	confGroup.Spec.ValidateHealthJobs = c.ValidateHealthJobs
 	confGroup.Spec.PreDeleteChecks = c.PreDeleteChecks
+	confGroup.Spec.PreDeleteCheckJobs = c.PreDeleteCheckJobs
 	confGroup.Spec.PostDeleteChecks = c.PostDeleteChecks
+	confGroup.Spec.PostDeleteCheckJobs = c.PostDeleteCheckJobs
 	confGroup.Spec.PreDeployChecks = c.PreDeployChecks
+	confGroup.Spec.PreDeployCheckJobs = c.PreDeployCheckJobs
 
 	if c.DryRun {
 		confGroup.Spec.DryRun = true

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -214,6 +214,14 @@ spec:
                   This setting applies only to feature deployments, not resource removal.
                   This field is optional. If not set, Sveltos default behavior is to keep retrying.
                 type: integer
+              postDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PostDeleteCheckJobs holds the resolved manifest for every PostDeleteChecks entry that
+                  uses JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead
+                  of time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               postDeleteChecks:
                 description: |-
                   PostDeleteChecks is a slice of checks to run against the managed cluster
@@ -427,6 +435,14 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeleteCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeleteCheckJobs holds the resolved manifest for every PreDeleteChecks entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               preDeleteChecks:
                 description: |-
                   PreDeleteChecks is a slice of checks to run against the managed cluster
@@ -640,6 +656,20 @@ spec:
                     rule: '!has(self.jobCheck) || (!has(self.script) && !has(self.evaluateCEL))'
                 type: array
                 x-kubernetes-list-type: atomic
+              preDeployCheckJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PreDeployCheckJobs holds the resolved manifest for every PreDeployChecks entry that uses
+                  JobCheck, keyed by "<namespace>/<name>" (the namespace/name JobHealthCheck.JobRef
+                  resolves to). The value is the YAML-encoded Job manifest.
+                  JobCheck requires a Sveltos Enterprise license, which sveltos-applier (an open-source
+                  binary) cannot verify on its own, so addon-controller resolves each Job manifest once,
+                  up front - fetching JobRef's ConfigMap/Secret and applying Cluster-field templating -
+                  and stages the result here. Sveltos-applier only ever runs the already-resolved Job; it
+                  never fetches JobRef or checks licensing itself.
+                  Empty when no PreDeployChecks entry uses JobCheck.
+                type: object
               preDeployChecks:
                 description: |-
                   PreDeployChecks is a slice of checks to run against the managed cluster
@@ -967,6 +997,14 @@ spec:
                 - Ready
                 - Preparing
                 type: string
+              validateHealthJobs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ValidateHealthJobs holds the resolved manifest for every ValidateHealths entry that uses
+                  JobCheck. See PreDeployCheckJobs for the key format and why this is resolved ahead of
+                  time by addon-controller rather than fetched by sveltos-applier.
+                type: object
               validateHealths:
                 description: |-
                   ValidateHealths is a slice of checks to run against the managed cluster


### PR DESCRIPTION
ConfigurationGroup contains now all Jobs that need to run to validate health.