### PR TITLE
fix: set owner reference on version-tracking ConfigMaps for GC

### DIFF
--- a/lib/sveltos_upgrade/suite_test.go
+++ b/lib/sveltos_upgrade/suite_test.go
@@ -21,10 +21,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
 var (
@@ -41,6 +44,10 @@ var _ = BeforeSuite(func() {
 
 	scheme = runtime.NewScheme()
 	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+	err = clusterv1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+	err = libsveltosv1beta1.AddToScheme(scheme)
 	Expect(err).To(BeNil())
 })
 

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade.go
@@ -27,11 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/go-logr/logr"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clustercache"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
@@ -201,6 +203,11 @@ func StoreSveltosAgentVersion(ctx context.Context, c client.Client,
 	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
 
+	owner, err := getConfigMapOwner(ctx, c, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	if err != nil {
+		return err
+	}
+
 	lbls := getLabels(clusterName, clusterType)
 	lbls[agentTypeLabel] = sveltosAgentType
 
@@ -208,7 +215,7 @@ func StoreSveltosAgentVersion(ctx context.Context, c client.Client,
 	cm, err := getConfigMap(ctx, c, cmInfo, logger)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return createConfigMap(ctx, c, version, cmInfo, lbls)
+			return createConfigMap(ctx, c, version, cmInfo, lbls, owner)
 		}
 		return err
 	}
@@ -218,6 +225,11 @@ func StoreSveltosAgentVersion(ctx context.Context, c client.Client,
 		cm.Data = map[string]string{}
 	}
 	cm.Data[configMapKey] = version
+	if owner != nil {
+		if err := controllerutil.SetOwnerReference(owner, cm, c.Scheme()); err != nil {
+			return err
+		}
+	}
 	return c.Update(ctx, cm)
 }
 
@@ -232,6 +244,11 @@ func StoreDriftDetectionVersion(ctx context.Context, c client.Client,
 	sveltosNamespace, version, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
 
+	owner, err := getConfigMapOwner(ctx, c, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode)
+	if err != nil {
+		return err
+	}
+
 	lbls := getLabels(clusterName, clusterType)
 	lbls[agentTypeLabel] = driftDetectionType
 
@@ -239,7 +256,7 @@ func StoreDriftDetectionVersion(ctx context.Context, c client.Client,
 	cm, err := getConfigMap(ctx, c, cmInfo, logger)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return createConfigMap(ctx, c, version, cmInfo, lbls)
+			return createConfigMap(ctx, c, version, cmInfo, lbls, owner)
 		}
 		return err
 	}
@@ -249,11 +266,30 @@ func StoreDriftDetectionVersion(ctx context.Context, c client.Client,
 		cm.Data = map[string]string{}
 	}
 	cm.Data[configMapKey] = version
+	if owner != nil {
+		if err := controllerutil.SetOwnerReference(owner, cm, c.Scheme()); err != nil {
+			return err
+		}
+	}
 	return c.Update(ctx, cm)
 }
 
+// getConfigMapOwner returns the object that should own the per-cluster version-tracking
+// ConfigMap, so it gets garbage collected together with the cluster it tracks. This only
+// applies when the agent runs in the management cluster: the ConfigMap it creates there
+// lives independently of the managed cluster and would otherwise never be cleaned up. When
+// the agent runs in the managed cluster itself, the ConfigMap already dies with that cluster.
+func getConfigMapOwner(ctx context.Context, c client.Client, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool) (client.Object, error) {
+
+	if !isAgentInMgmtMode {
+		return nil, nil
+	}
+	return clusterproxy.GetCluster(ctx, c, clusterNamespace, clusterName, clusterType)
+}
+
 func createConfigMap(ctx context.Context, c client.Client, version string,
-	info types.NamespacedName, lbls map[string]string) error {
+	info types.NamespacedName, lbls map[string]string, owner client.Object) error {
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -265,6 +301,13 @@ func createConfigMap(ctx context.Context, c client.Client, version string,
 			configMapKey: version,
 		},
 	}
+
+	if owner != nil {
+		if err := controllerutil.SetOwnerReference(owner, cm, c.Scheme()); err != nil {
+			return err
+		}
+	}
+
 	return c.Create(ctx, cm)
 }
 

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
@@ -24,9 +24,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -37,6 +39,38 @@ import (
 const (
 	version = "v1.31.0"
 )
+
+// createOwnerCluster creates the CAPI Cluster or SveltosCluster object that owns the
+// per-cluster version-tracking ConfigMap when the agent runs in the management cluster.
+// The fake client does not auto-assign a UID, so one is set explicitly: without it, an
+// assertion against OwnerReferences[0].UID would be vacuous (comparing empty to empty).
+func createOwnerCluster(c client.Client, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) types.UID {
+
+	uid := types.UID(randomString())
+
+	var obj client.Object
+	if clusterType == libsveltosv1beta1.ClusterTypeSveltos {
+		obj = &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+				UID:       uid,
+			},
+		}
+	} else {
+		obj = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+				UID:       uid,
+			},
+		}
+	}
+
+	Expect(c.Create(context.TODO(), obj)).To(Succeed())
+	return uid
+}
 
 var _ = Describe("SveltosAgent compatibility checks", func() {
 	var logger logr.Logger
@@ -64,6 +98,8 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
 
+		ownerUID := createOwnerCluster(c, clusterNamespace, clusterName, clusterType)
+
 		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
 			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
@@ -72,6 +108,8 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+		Expect(cm.OwnerReferences).To(HaveLen(1))
+		Expect(cm.OwnerReferences[0].UID).To(Equal(ownerUID))
 	})
 
 	It("Update ConfigMap with Sveltos-agent version", func() {
@@ -101,6 +139,8 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
 
+		ownerUID := createOwnerCluster(c, clusterNamespace, clusterName, clusterType)
+
 		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
 			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 		name := sveltos_upgrade.GenerateName(sveltos_upgrade.SveltosAgentType, clusterName, clusterType)
@@ -112,6 +152,8 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+		Expect(cm.OwnerReferences).To(HaveLen(1))
+		Expect(cm.OwnerReferences[0].UID).To(Equal(ownerUID))
 	})
 
 	It("IsSveltosAgentVersionCompatible returns true Sveltos-agent version is compatible (agent in management cluster)", func() {
@@ -197,6 +239,8 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeCapi
 
+		ownerUID := createOwnerCluster(c, clusterNamespace, clusterName, clusterType)
+
 		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
 			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
@@ -205,6 +249,8 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+		Expect(cm.OwnerReferences).To(HaveLen(1))
+		Expect(cm.OwnerReferences[0].UID).To(Equal(ownerUID))
 	})
 
 	It("Update ConfigMap with drift-detection-manager version", func() {
@@ -234,6 +280,8 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 		clusterName := randomString()
 		clusterType := libsveltosv1beta1.ClusterTypeSveltos
 
+		ownerUID := createOwnerCluster(c, clusterNamespace, clusterName, clusterType)
+
 		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
 			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
 
@@ -245,5 +293,25 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+		Expect(cm.OwnerReferences).To(HaveLen(1))
+		Expect(cm.OwnerReferences[0].UID).To(Equal(ownerUID))
+	})
+
+	It("StoreDriftDetectionVersion returns NotFound and creates no ConfigMap when the owning cluster is missing", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+
+		err := sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+		name := sveltos_upgrade.GenerateName(sveltos_upgrade.DriftDetectionType, clusterName, clusterType)
+		cm := &corev1.ConfigMap{}
+		err = c.Get(context.TODO(), types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
When the sveltos-agent/drift-detection-manager version ConfigMap is created in the management cluster, set the tracked cluster (CAPI `Cluster` or `SveltosCluster`) as its owner reference so it is garbage collected together with the cluster it tracks. Previously these per-cluster ConfigMaps were left orphaned after cluster deletion since they live independently of the managed cluster.

Applies only when the agent runs in management-cluster mode — when the agent runs inside the managed cluster itself, the ConfigMap already gets cleaned up with that cluster.