### PR TITLE
Add Delete{SveltosAgent,DriftDetection}Version

### DIFF
--- a/lib/sveltos_upgrade/sveltos_agent_upgrade.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade.go
@@ -252,6 +252,48 @@ func StoreDriftDetectionVersion(ctx context.Context, c client.Client,
 	return c.Update(ctx, cm)
 }
 
+// DeleteSveltosAgentVersion deletes the ConfigMap that stores the Sveltos-agent version, if
+// present. It is a no-op if the ConfigMap does not exist. See StoreSveltosAgentVersion for how
+// the ConfigMap identity is derived.
+func DeleteSveltosAgentVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
+
+	return deleteConfigMap(ctx, c,
+		getSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode),
+		logger)
+}
+
+// DeleteDriftDetectionVersion deletes the ConfigMap that stores the drift-detection-manager
+// version, if present. It is a no-op if the ConfigMap does not exist. See
+// StoreDriftDetectionVersion for how the ConfigMap identity is derived.
+func DeleteDriftDetectionVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
+
+	return deleteConfigMap(ctx, c,
+		getDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode),
+		logger)
+}
+
+func deleteConfigMap(ctx context.Context, c client.Client, cmInfo types.NamespacedName,
+	logger logr.Logger) error {
+
+	cm, err := getConfigMap(ctx, c, cmInfo, logger)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = c.Delete(ctx, cm)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 func createConfigMap(ctx context.Context, c client.Client, version string,
 	info types.NamespacedName, lbls map[string]string) error {
 

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
@@ -141,6 +142,36 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, sveltosNamespace, randomString(),
 			clusterNamespace, clusterName, clusterType, true, logger)).To(BeFalse())
 	})
+
+	It("DeleteSveltosAgentVersion deletes the ConfigMap", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		name := sveltos_upgrade.GenerateName(sveltos_upgrade.SveltosAgentType, clusterName, clusterType)
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
+
+		Expect(sveltos_upgrade.DeleteSveltosAgentVersion(context.TODO(), c, sveltosNamespace,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		err := c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("DeleteSveltosAgentVersion is a no-op when the ConfigMap does not exist", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		Expect(sveltos_upgrade.DeleteSveltosAgentVersion(context.TODO(), c, sveltosNamespace,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, true, logger)).To(Succeed())
+	})
 })
 
 var _ = Describe("DriftDetection compatibility checks", func() {
@@ -245,5 +276,35 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+	})
+
+	It("DeleteDriftDetectionVersion deletes the ConfigMap", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		clusterType := libsveltosv1beta1.ClusterTypeSveltos
+
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		name := sveltos_upgrade.GenerateName(sveltos_upgrade.DriftDetectionType, clusterName, clusterType)
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
+
+		Expect(sveltos_upgrade.DeleteDriftDetectionVersion(context.TODO(), c, sveltosNamespace,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		err := c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("DeleteDriftDetectionVersion is a no-op when the ConfigMap does not exist", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		Expect(sveltos_upgrade.DeleteDriftDetectionVersion(context.TODO(), c, sveltosNamespace,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeSveltos, true, logger)).To(Succeed())
 	})
 })


### PR DESCRIPTION
Follow-up to #670, which gianlucam76 pointed out should be consistent with how addon-controller/classifier already clean up other stale per-cluster resources instead of using an owner reference.

Both addon-controller and classifier have a goroutine that finds resources belonging to a cluster that no longer exists and deletes them, but neither currently touches the version-tracking ConfigMap (`sa-*`/`dd-*`) the agent leaves behind in the management cluster, so it's orphaned forever once the cluster is gone.

This adds `DeleteSveltosAgentVersion` and `DeleteDriftDetectionVersion`, symmetric with the existing `Store*`/`Is*` pair for each agent type, so addon-controller and classifier can call them from their existing cleanup goroutines. Wiring those up is a separate PR in each of those repos.