### PR TITLE
Add Delete{SveltosAgent,DriftDetection}Version

### DIFF
--- a/lib/sveltos_upgrade/sveltos_agent_upgrade.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade.go
@@ -227,6 +227,48 @@ func StoreDriftDetectionVersion(ctx context.Context, c client.Client, version, c
 	return c.Update(ctx, cm)
 }
 
+// DeleteSveltosAgentVersion deletes the ConfigMap that stores the Sveltos-agent version, if
+// present. It is a no-op if the ConfigMap does not exist. See StoreSveltosAgentVersion for how
+// the ConfigMap identity is derived.
+func DeleteSveltosAgentVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
+
+	return deleteConfigMap(ctx, c,
+		getSveltosAgentConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode),
+		logger)
+}
+
+// DeleteDriftDetectionVersion deletes the ConfigMap that stores the drift-detection-manager
+// version, if present. It is a no-op if the ConfigMap does not exist. See
+// StoreDriftDetectionVersion for how the ConfigMap identity is derived.
+func DeleteDriftDetectionVersion(ctx context.Context, c client.Client,
+	sveltosNamespace, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, isAgentInMgmtMode bool, logger logr.Logger) error {
+
+	return deleteConfigMap(ctx, c,
+		getDriftDetectionConfigMapInfo(sveltosNamespace, clusterNamespace, clusterName, clusterType, isAgentInMgmtMode),
+		logger)
+}
+
+func deleteConfigMap(ctx context.Context, c client.Client, cmInfo types.NamespacedName,
+	logger logr.Logger) error {
+
+	cm, err := getConfigMap(ctx, c, cmInfo, logger)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = c.Delete(ctx, cm)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 func createConfigMap(ctx context.Context, c client.Client, version string,
 	info types.NamespacedName, lbls map[string]string) error {
 

--- a/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
+++ b/lib/sveltos_upgrade/sveltos_agent_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
@@ -139,6 +140,36 @@ var _ = Describe("SveltosAgent compatibility checks", func() {
 		Expect(sveltos_upgrade.IsSveltosAgentVersionCompatible(context.TODO(), c, randomString(), clusterNamespace, clusterName,
 			clusterType, true, logger)).To(BeFalse())
 	})
+
+	It("DeleteSveltosAgentVersion deletes the ConfigMap", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+
+		Expect(sveltos_upgrade.StoreSveltosAgentVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		name := sveltos_upgrade.GenerateName(sveltos_upgrade.SveltosAgentType, clusterName, clusterType)
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
+
+		Expect(sveltos_upgrade.DeleteSveltosAgentVersion(context.TODO(), c, sveltosNamespace,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		err := c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("DeleteSveltosAgentVersion is a no-op when the ConfigMap does not exist", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		Expect(sveltos_upgrade.DeleteSveltosAgentVersion(context.TODO(), c, sveltosNamespace,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, true, logger)).To(Succeed())
+	})
 })
 
 var _ = Describe("DriftDetection compatibility checks", func() {
@@ -241,5 +272,35 @@ var _ = Describe("DriftDetection compatibility checks", func() {
 			cm)).To(Succeed())
 		Expect(cm.Data).ToNot(BeNil())
 		Expect(cm.Data[sveltos_upgrade.ConfigMapKey]).To(Equal(version))
+	})
+
+	It("DeleteDriftDetectionVersion deletes the ConfigMap", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterNamespace := randomString()
+		clusterName := randomString()
+		clusterType := libsveltosv1beta1.ClusterTypeSveltos
+
+		Expect(sveltos_upgrade.StoreDriftDetectionVersion(context.TODO(), c, sveltosNamespace, version,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		name := sveltos_upgrade.GenerateName(sveltos_upgrade.DriftDetectionType, clusterName, clusterType)
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)).To(Succeed())
+
+		Expect(sveltos_upgrade.DeleteDriftDetectionVersion(context.TODO(), c, sveltosNamespace,
+			clusterNamespace, clusterName, clusterType, true, logger)).To(Succeed())
+
+		err := c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: name}, cm)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("DeleteDriftDetectionVersion is a no-op when the ConfigMap does not exist", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		Expect(sveltos_upgrade.DeleteDriftDetectionVersion(context.TODO(), c, sveltosNamespace,
+			randomString(), randomString(), libsveltosv1beta1.ClusterTypeSveltos, true, logger)).To(Succeed())
 	})
 })


### PR DESCRIPTION
addon-controller and classifier both already have a goroutine that cleans up stale per-cluster resources once the cluster they belong to is gone, but neither one touches the version-tracking ConfigMap the agent leaves behind, so it's orphaned forever. Give them a function to get and delete it, symmetric with the existing Store*/Is* pair for each agent type.