### PR TITLE
fix: self-evict workload identity cache on 401/403

### DIFF
--- a/lib/clusterproxy/workload_identity.go
+++ b/lib/clusterproxy/workload_identity.go
@@ -94,6 +94,52 @@ func wiCacheKey(namespace, name string) string {
 	return namespace + "/" + name
 }
 
+// wiAuthInvalidatingTransport wraps a cluster's http.RoundTripper so that any 401/403
+// response evicts this cluster's workload-identity cache entry as a side effect. This
+// catches a token being rejected for a reason its own expiry does not predict (early
+// revocation, an IdP restart invalidating outstanding tokens, and similar), so the next
+// call gets a freshly fetched token instead of repeating the same rejected one until the
+// proactive refresh threshold in getWorkloadIdentityRestConfig eventually catches up.
+//
+// This mirrors clustercache's authInvalidatingTransport, one layer down: clustercache
+// wraps this same eviction into its own transport for callers that go through
+// GetKubernetesRestConfig/GetKubernetesClient, but a caller using
+// GetSveltosKubernetesRestConfig/GetKubernetesRestConfig directly, bypassing clustercache,
+// previously got none of that. Duplicated rather than shared because clustercache already
+// imports this package for EvictWorkloadIdentityCache; the reverse import would cycle.
+type wiAuthInvalidatingTransport struct {
+	base             http.RoundTripper
+	clusterNamespace string
+	clusterName      string
+}
+
+func (t *wiAuthInvalidatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+		EvictWorkloadIdentityCache(t.clusterNamespace, t.clusterName)
+	}
+	return resp, err
+}
+
+// wrapWithWorkloadIdentityAuthInvalidation returns a copy of cfg whose transport evicts
+// this cluster's workload-identity cache entry on any 401/403. Preserves whatever
+// WrapTransport cfg already carried.
+func wrapWithWorkloadIdentityAuthInvalidation(cfg *rest.Config, clusterNamespace, clusterName string) *rest.Config {
+	cfg = rest.CopyConfig(cfg)
+	base := cfg.WrapTransport
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if base != nil {
+			rt = base(rt)
+		}
+		return &wiAuthInvalidatingTransport{
+			base:             rt,
+			clusterNamespace: clusterNamespace,
+			clusterName:      clusterName,
+		}
+	}
+	return cfg
+}
+
 // workloadIdentityConfigHash returns a stable hash of a WorkloadIdentityConfig, used to
 // detect when spec.workloadIdentity changes (provider, endpoint, cloud-specific fields,
 // or which CA Secret is referenced) so a stale cached rest.Config is not reused.
@@ -164,6 +210,7 @@ func getWorkloadIdentityRestConfig(
 			return nil, err
 		}
 
+		cfg = wrapWithWorkloadIdentityAuthInvalidation(cfg, clusterNamespace, clusterName)
 		wiCache.Store(key, cachedRestConfig{config: cfg, expiresAt: expiresAt, specHash: specHash})
 		return result{cfg: cfg}, nil
 	})

--- a/lib/clusterproxy/workload_identity_test.go
+++ b/lib/clusterproxy/workload_identity_test.go
@@ -418,4 +418,71 @@ var _ = Describe("WorkloadIdentity OIDC", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("failed to obtain OIDC access token"))
 	})
+
+	It("self-evicts the cache when a request through the returned config gets a 401, with no explicit eviction call",
+		func() {
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600}`))
+			}))
+			defer tokenServer.Close()
+
+			// The managed cluster's own API server, separate from the IdP: this is what
+			// GetSveltosKubernetesRestConfig's returned config actually points requests at.
+			apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer apiServer.Close()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: oidcNS,
+					Name:      oidcSecretName,
+				},
+				Data: map[string][]byte{
+					oidcClientIDKey:   []byte(oidcClientID),
+					oidcSecretDataKey: []byte(oidcClientSecret),
+				},
+			}
+
+			wi := &libsveltosv1beta1.WorkloadIdentityConfig{
+				Provider: libsveltosv1beta1.WorkloadIdentityProviderOIDC,
+				Endpoint: apiServer.URL,
+				OIDC: &libsveltosv1beta1.OIDCWorkloadIdentityConfig{
+					TokenURL:  tokenServer.URL,
+					SecretRef: corev1.SecretReference{Name: oidcSecretName, Namespace: oidcNS},
+				},
+			}
+			sveltosCluster := &libsveltosv1beta1.SveltosCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: oidcNS,
+					Name:      oidcClusterName,
+				},
+				Spec: libsveltosv1beta1.SveltosClusterSpec{
+					WorkloadIdentity: wi,
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sveltosCluster, secret).Build()
+			logger := logr.Discard()
+
+			got, err := clusterproxy.GetSveltosKubernetesRestConfig(ctx, logger, c, oidcNS, oidcClusterName)
+			Expect(err).To(BeNil())
+
+			_, _, ok := clusterproxy.LoadTestWiCache(oidcNS, oidcClusterName)
+			Expect(ok).To(BeTrue())
+
+			// Issue one request through the returned config. The mock API server always answers
+			// 401: nothing here calls EvictWorkloadIdentityCache, eviction must happen as a side
+			// effect of the transport GetSveltosKubernetesRestConfig installed.
+			httpClient, err := rest.HTTPClientFor(got)
+			Expect(err).To(BeNil())
+			resp, err := httpClient.Get(apiServer.URL)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Body.Close()).To(Succeed())
+
+			_, _, ok = clusterproxy.LoadTestWiCache(oidcNS, oidcClusterName)
+			Expect(ok).To(BeFalse())
+		})
 })


### PR DESCRIPTION
getWorkloadIdentityRestConfig only refreshed a cached token proactively, 5 minutes ahead of its own recorded expiry. A token rejected for a reason that expiry does not predict (early revocation, an IdP restart invalidating outstanding tokens, or similar) kept being reused until that window caught up, since nothing evicted it in response to the managed cluster's API server actually rejecting it.

Wrap the returned rest.Config's transport so any 401/403 response evicts this cluster's cache entry immediately, the same self-evicting pattern clustercache.GetKubernetesRestConfig already applies for its own callers. Duplicated here rather than shared because clustercache imports this package for EvictWorkloadIdentityCache; the reverse import would cycle. A caller going through GetSveltosKubernetesRestConfig directly, bypassing clustercache entirely, previously got neither.