### PR TITLE
feat: Extend FeatureStatus with Blocked

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -440,7 +440,7 @@ type ValidateHealth struct {
 	JobCheck *JobHealthCheck `json:"jobCheck,omitempty"`
 }
 
-// +kubebuilder:validation:Enum:=Provisioning;Provisioned;Failed;FailedNonRetriable;Removing;Removed;AgentRemoving
+// +kubebuilder:validation:Enum:=Provisioning;Provisioned;Failed;FailedNonRetriable;Removing;Removed;AgentRemoving;Blocked
 type FeatureStatus string
 
 const (
@@ -470,6 +470,11 @@ const (
 
 	// FeatureStatusRemoved indicates that feature is removed
 	FeatureStatusRemoved = FeatureStatus("Removed")
+
+	// FeatureStatusBlocked indicates that removal of this feature is deferred:
+	// a dependent ClusterSummary (DependsOn) has not been removed yet, or a
+	// successor ClusterSummary (TransitionFrom) has not reached Provisioned yet.
+	FeatureStatusBlocked = FeatureStatus("Blocked")
 )
 
 type FeatureDeploymentInfo struct {

--- a/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_configurationgroups.yaml
@@ -1276,6 +1276,7 @@ spec:
                 - Removing
                 - Removed
                 - AgentRemoving
+                - Blocked
                 type: string
             type: object
         type: object

--- a/lib/crd/configurationgroups.go
+++ b/lib/crd/configurationgroups.go
@@ -1294,6 +1294,7 @@ spec:
                 - Removing
                 - Removed
                 - AgentRemoving
+                - Blocked
                 type: string
             type: object
         type: object

--- a/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+++ b/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
@@ -1275,6 +1275,7 @@ spec:
                 - Removing
                 - Removed
                 - AgentRemoving
+                - Blocked
                 type: string
             type: object
         type: object


### PR DESCRIPTION
This status is used when processing a clusterSummary is blocked because either a dependant is still present or a successor is not yet fully deployed